### PR TITLE
relevance: trunks from synced local corpus cache (live fetch as fallback)

### DIFF
--- a/packages/adapter-ticktick/relevance.js
+++ b/packages/adapter-ticktick/relevance.js
@@ -6,26 +6,77 @@
  * canonical "Trunk Catalog" note in the configured wiki project) and follow up with
  * `ats tasks update` to append a `why:` line.
  *
- * Trunks are fetched fresh from TickTick on every call — a single REST GET
- * (~200-500ms). No local cache file. The Trunk Catalog note is the single
- * source of truth.
+ * Local-JSON-first: trunks are read from the synced on-disk corpus cache (the
+ * same `corpus-cache.json` that backs `tasks find`). The cache is the primary
+ * source so capture-time enrichment costs no network round-trip. A live REST
+ * GET is only the fallback — used when the cache is missing, stale (past its
+ * TTL), or does not yet contain the Trunk Catalog note. The note itself remains
+ * the canonical source of truth; the cache is just a synced local mirror.
  *
  * Fail-open: any error fetching trunks → returns empty string → no
  * enrichment block printed → task creation still succeeds normally.
  */
 
 import * as notes from './notes.js';
+import * as corpusCache from '@reneza/ats-core/corpus-cache';
 
 const TRUNK_CATALOG_TITLE = 'Trunk Catalog';
 const trunkCatalogProject = (configured) => configured || process.env.ATS_WIKI_PROJECT || 'Permanent Notes';
 
-async function fetchTrunks(deps, project) {
+// Match a project name the way the rest of the adapter does — strip leading
+// emojis/symbols so a decorated wiki name ("🌳 Permanent Notes") still resolves.
+const stripDecorations = (s) =>
+  (s || '').normalize('NFKC').replace(/^[^\p{L}\p{N}]+/u, '').trim().toLowerCase();
+
+// Pull the `trunks` array out of a note body's first fenced ```json block.
+function extractTrunksJson(content) {
+  const m = (content || '').match(/```json\s*\n([\s\S]*?)\n```/);
+  if (!m) return null;
+  try {
+    const data = JSON.parse(m[1]);
+    return Array.isArray(data?.trunks) ? data.trunks : null;
+  } catch {
+    return null;
+  }
+}
+
+// Read the Trunk Catalog from the synced local corpus cache. Returns the trunks
+// array (possibly empty) when the note is present and parseable, or null on any
+// miss (cache absent/stale/disabled, note not yet cached, malformed JSON) so the
+// caller can fall back to a live fetch.
+function trunksFromCache(project, deps = {}) {
+  const read = deps.readCorpus || corpusCache.read;
+  let cached;
+  try {
+    cached = read();
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(cached)) return null;
+  const target = stripDecorations(trunkCatalogProject(project));
+  const note = cached.find(
+    (t) => stripDecorations(t.projectName) === target && (t.title || '') === TRUNK_CATALOG_TITLE
+  );
+  if (!note) return null;
+  return extractTrunksJson(note.content);
+}
+
+// Live fallback: a single REST GET for the Trunk Catalog note.
+async function fetchTrunksLive(deps, project) {
   const data = await notes.get(
     TRUNK_CATALOG_TITLE,
     { project: trunkCatalogProject(project), extract: 'json', exact: false },
     deps
   );
   return Array.isArray(data?.trunks) ? data.trunks : [];
+}
+
+// Local-JSON-first: the synced corpus cache is primary; fall back to a live
+// REST GET only when the cache has nothing usable for us.
+async function fetchTrunks(deps, project) {
+  const fromCache = trunksFromCache(project, deps);
+  if (fromCache !== null) return fromCache;
+  return fetchTrunksLive(deps, project);
 }
 
 function trunksBlock(trunks) {

--- a/packages/adapter-ticktick/test/relevance.test.js
+++ b/packages/adapter-ticktick/test/relevance.test.js
@@ -3,13 +3,18 @@ import assert from 'node:assert/strict';
 import { buildEnrichInstruction, isEnabled } from '../relevance.js';
 
 const original = process.env.ATS_RELEVANCE;
+const originalCacheDisable = process.env.ATS_CORPUS_CACHE_DISABLE;
 
 afterEach(() => {
   if (original === undefined) delete process.env.ATS_RELEVANCE;
   else process.env.ATS_RELEVANCE = original;
+  if (originalCacheDisable === undefined) delete process.env.ATS_CORPUS_CACHE_DISABLE;
+  else process.env.ATS_CORPUS_CACHE_DISABLE = originalCacheDisable;
 });
 
 test('relevance enrichment emits ATS-only follow-up commands', async () => {
+  // Force the live fallback: no on-disk corpus cache should be consulted here.
+  process.env.ATS_CORPUS_CACHE_DISABLE = '1';
   const apiRequest = async (_method, endpoint) => {
     if (endpoint === '/project') return [{ id: 'notes-project-123456789', name: 'Permanent Notes' }];
     if (endpoint.includes('/data')) {
@@ -32,6 +37,7 @@ test('ATS_RELEVANCE controls default enrichment', () => {
 });
 
 test('relevance enrichment honors the configured wiki project', async () => {
+  process.env.ATS_CORPUS_CACHE_DISABLE = '1';
   const seen = [];
   const apiRequest = async (_method, endpoint) => {
     seen.push(endpoint);
@@ -50,4 +56,48 @@ test('relevance enrichment honors the configured wiki project', async () => {
   );
   assert.match(block, /quality/);
   assert.ok(seen.some((endpoint) => endpoint.includes('custom-project-123456789')));
+});
+
+test('relevance reads trunks from the synced corpus cache without a live fetch', async () => {
+  // Synced local corpus mirror — the Trunk Catalog note as `tasks find` stores it.
+  const readCorpus = () => [
+    { title: 'Some other note', projectName: 'Permanent Notes', content: 'irrelevant' },
+    {
+      title: 'Trunk Catalog',
+      projectName: 'Permanent Notes',
+      content: '```json\n{"trunks":[{"name":"delivery","desc":"shipping work"}]}\n```',
+    },
+  ];
+  // If the live path is touched, fail loudly — the cache must be primary.
+  const apiRequest = async (_method, endpoint) => {
+    throw new Error(`live fetch should not run, but hit: ${endpoint}`);
+  };
+  const block = await buildEnrichInstruction(
+    { taskId: 't3', projectId: 'p3', title: 'Probe', content: '' },
+    { readCorpus, apiRequest }
+  );
+  assert.match(block, /delivery/);
+  assert.match(block, /ats tasks update p3 t3/);
+});
+
+test('relevance falls back to a live fetch when the cache lacks the catalog', async () => {
+  const readCorpus = () => [{ title: 'Unrelated', projectName: 'Permanent Notes', content: 'no catalog here' }];
+  const seen = [];
+  const apiRequest = async (_method, endpoint) => {
+    seen.push(endpoint);
+    if (endpoint === '/project') return [{ id: 'notes-project-123456789', name: 'Permanent Notes' }];
+    if (endpoint.includes('/data')) {
+      return { tasks: [{ id: 'trunk-task-123456789', projectId: 'notes-project-123456789', title: 'Trunk Catalog' }] };
+    }
+    if (endpoint.includes('/task/')) {
+      return { id: 'trunk-task-123456789', projectId: 'notes-project-123456789', title: 'Trunk Catalog', content: '```json\n{"trunks":[{"name":"delivery","desc":"shipping work"}]}\n```' };
+    }
+    throw new Error(`unexpected endpoint: ${endpoint}`);
+  };
+  const block = await buildEnrichInstruction(
+    { taskId: 't4', projectId: 'p4', title: 'Probe', content: '' },
+    { readCorpus, apiRequest }
+  );
+  assert.match(block, /delivery/);
+  assert.ok(seen.some((endpoint) => endpoint.includes('/task/')));
 });


### PR DESCRIPTION
## What

Capture-time trunk enrichment (`buildEnrichInstruction` → `fetchTrunks` in `relevance.js`) previously did a live REST GET to the Trunk Catalog note on **every** `ats tasks create`. This makes the synced on-disk `corpus-cache.json` — the same local mirror that already backs `tasks find` — the **primary** source, with a live fetch only as a fallback.

## Why

The corpus cache is a synced local JSON mirror of the task store. Reading trunks from it removes a per-create network round-trip on the common path, and lets enrichment work offline. The Trunk Catalog note remains the canonical source of truth; the cache is just the local-first read path.

## Behavior

`fetchTrunks` now:
1. Reads the Trunk Catalog from the corpus cache (matched by decoration-stripped project name + title).
2. Returns those trunks when present (respects the cache's existing TTL/disable env).
3. Falls back to a live REST GET when the cache is missing, stale, disabled, or lacks the catalog note.

Fail-open semantics unchanged: any error → empty enrichment block → task creation still succeeds.

## Tests

- Full suite: **178/178 pass**.
- New: cache-first path returns trunks with the live `apiRequest` wired to throw (proves no network).
- New: fallback path hits the live `/task/` endpoint when the cache lacks the catalog.
- Existing live-path tests pinned with `ATS_CORPUS_CACHE_DISABLE=1` for determinism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)