### PR TITLE
task-context: links live in a human-readable "## Related" deep-link section

### DIFF
--- a/docs/agent-layer.md
+++ b/docs/agent-layer.md
@@ -4,7 +4,9 @@ Retrieval answers: "what looks relevant?" ATS's execution layer adds the informa
 
 ## Portable task metadata
 
-ATS stores one managed JSON block at the end of the normal task body. The human-authored markdown remains untouched. Because the block travels through the existing `content` field, every adapter that implements the six-method contract supports it without a backend migration.
+ATS stores one managed JSON block at the end of the normal task body, holding intent, lifecycle, hierarchy, and security. The human-authored markdown remains untouched. Because the block travels through the existing `content` field, every adapter that implements the six-method contract supports it without a backend migration.
+
+Typed cross-task links live separately, in a human-readable `## Related` section near the bottom of the body, so a person reading the task in their storage app sees clickable deep links instead of opaque IDs (and the agent reads the same lines).
 
 ```json
 {
@@ -31,18 +33,21 @@ ATS stores one managed JSON block at the end of the normal task body. The human-
     "deniedResources": ["repo://sample-release/private/*"],
     "approvalRequiredFor": ["write"],
     "approvers": ["sample-release-owner"]
-  },
-  "links": [
-    {
-      "type": "decision",
-      "projectId": "demo",
-      "taskId": "decision-17"
-    }
-  ]
+  }
 }
 ```
 
 Malformed managed blocks fail closed: ATS refuses to overwrite them until they are repaired.
+
+Typed links render in the `## Related` section as `- <type>: [<title>](<deep-link>)`, one bullet per link:
+
+```markdown
+## Related
+- decision: [Approved release decision](https://ticktick.com/webapp/#p/demo/tasks/decision-17)
+- depends-on: [Auth spec](https://ticktick.com/webapp/#p/demo/tasks/auth-spec)
+```
+
+ATS reconstructs each link's `projectId`/`taskId` from the deep-link URL, so `ats link`, `ats graph`, and `ats context` are unchanged. Links written before this format are read from the legacy JSON block for backward compatibility and migrate to the `## Related` section on the next write.
 
 ## CLI
 

--- a/packages/core/task-context.js
+++ b/packages/core/task-context.js
@@ -22,6 +22,17 @@ const BLOCK_START = '<!-- ats:context -->';
 const BLOCK_END = '<!-- /ats:context -->';
 const BLOCK_RE = /<!-- ats:context -->\r?\n```ats\r?\n([\s\S]*?)\r?\n```\r?\n<!-- \/ats:context -->/g;
 
+// Typed cross-task links live in a human-readable "## Related" section near the
+// bottom of the task body — one bullet per link, `- <type>: [<title>](<url>)` —
+// instead of inside the machine block. The link text and deep-link URL serve a
+// human reader (and Obsidian-style backlink navigation); the agent reads the
+// same lines. projectId/taskId are recovered from the URL, so the in-memory
+// link model and everything downstream (graph/context/hierarchy) is unchanged.
+// The machine block keeps only intent/lifecycle/security/hierarchy.
+const RELATED_HEADING = '## Related';
+const RELATED_SECTION_RE = /(?:^|\n)##\s+Related[ \t]*\n([\s\S]*?)(?=\n#{1,6}\s|\n<!-- ats:context -->|$)/;
+const RELATED_LINE_RE = /^-\s+([a-z][a-z-]*):\s*\[([^\]]*)\]\(([^)]+)\)\s*$/;
+
 const emptyMetadata = () => ({
   version: TASK_CONTEXT_VERSION,
   intent: {
@@ -175,22 +186,94 @@ export function normalizeTaskMetadata(value = {}) {
   };
 }
 
+// Recover { projectId, taskId } from a link URL. Handles the TickTick native
+// deep link (…/#p/<proj>/tasks/<task>) and the generic <scheme>://<proj>/<task>
+// form adapters emit from urlFor(). Returns null when neither matches — such a
+// link stays visible to a human but is not added to the typed-link model.
+function parseRef(url) {
+  if (typeof url !== 'string' || !url) return null;
+  // TickTick native deep link: …/#p/<projectId>/tasks/<taskId>
+  let m = url.match(/#p\/([^/\s]+)\/tasks\/([^/?#\s)]+)/);
+  if (m) return { projectId: m[1], taskId: m[2] };
+  // Generic adapter deep link ending in …/<projectId>/<taskId>.
+  m = url.match(/^[a-z][a-z0-9+.-]*:\/\/(.+)$/i);
+  if (!m) return null;
+  const segments = m[1].split(/[?#]/)[0].split('/').map((s) => s.trim()).filter(Boolean);
+  if (segments.length < 2) return null;
+  return { projectId: segments[segments.length - 2], taskId: segments[segments.length - 1] };
+}
+
+function parseRelatedSection(text) {
+  const section = String(text || '').match(RELATED_SECTION_RE);
+  if (!section) return [];
+  const links = [];
+  for (const raw of section[1].split('\n')) {
+    const line = raw.trim();
+    if (!line) continue;
+    const m = line.match(RELATED_LINE_RE);
+    if (!m) continue;
+    const [, type, title, url] = m;
+    if (!LINK_TYPES.includes(type)) continue;
+    const ref = parseRef(url);
+    if (!ref) continue;
+    links.push({ type, projectId: ref.projectId, taskId: ref.taskId, title: title.trim(), url: url.trim() });
+  }
+  return links;
+}
+
+function renderRelatedSection(links) {
+  if (!links || links.length === 0) return '';
+  const lines = links.map((link) => {
+    // Prefer the adapter's real deep link; fall back to a parseable ref so a
+    // link added without a url (e.g. a direct writeTaskMetadata call) still
+    // round-trips its projectId/taskId.
+    const href = link.url || `ats://task/${link.projectId}/${link.taskId}`;
+    return `- ${link.type}: [${link.title || link.taskId}](${href})`;
+  });
+  return `${RELATED_HEADING}\n${lines.join('\n')}`;
+}
+
+function stripRelatedSection(text) {
+  return String(text || '').replace(RELATED_SECTION_RE, (match) => (match.startsWith('\n') ? '\n' : ''));
+}
+
+function mergeLinks(primary, secondary) {
+  const merged = [];
+  const seen = new Set();
+  for (const link of [...primary, ...secondary]) {
+    if (!link || typeof link !== 'object') continue;
+    const key = `${link.type}|${link.projectId}|${link.taskId}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(link);
+  }
+  return merged;
+}
+
 export function parseTaskMetadata(content = '') {
   const text = String(content || '');
   const matches = [...text.matchAll(BLOCK_RE)];
   const markerCount = text.split(BLOCK_START).length - 1;
   const endCount = text.split(BLOCK_END).length - 1;
-  if (markerCount === 0 && endCount === 0) return emptyMetadata();
-  if (markerCount !== 1 || endCount !== 1 || matches.length !== 1) {
-    throw new Error('Malformed ATS context block. Repair it before ATS writes metadata.');
+  let parsed = {};
+  if (markerCount !== 0 || endCount !== 0) {
+    if (markerCount !== 1 || endCount !== 1 || matches.length !== 1) {
+      throw new Error('Malformed ATS context block. Repair it before ATS writes metadata.');
+    }
+    try {
+      parsed = JSON.parse(matches[0][1]);
+    } catch (err) {
+      throw new Error(`Malformed ATS context JSON: ${err.message}`, { cause: err });
+    }
   }
-  let parsed;
-  try {
-    parsed = JSON.parse(matches[0][1]);
-  } catch (err) {
-    throw new Error(`Malformed ATS context JSON: ${err.message}`, { cause: err });
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return normalizeTaskMetadata(parsed);
   }
-  return normalizeTaskMetadata(parsed);
+  // Links now live in the "## Related" section. Legacy links still inside the
+  // machine block are read for back-compat and migrate to Related on next write.
+  const legacyLinks = Array.isArray(parsed.links) ? parsed.links : [];
+  const relatedLinks = parseRelatedSection(text);
+  return normalizeTaskMetadata({ ...parsed, links: mergeLinks(relatedLinks, legacyLinks) });
 }
 
 export function writeTaskMetadata(content = '', metadata = {}) {
@@ -202,9 +285,16 @@ export function writeTaskMetadata(content = '', metadata = {}) {
     throw new Error('Malformed ATS context block. Repair it before ATS writes metadata.');
   }
   const normalized = normalizeTaskMetadata(metadata);
-  const body = text.replace(BLOCK_RE, '').trimEnd();
-  const block = `${BLOCK_START}\n\`\`\`ats\n${JSON.stringify(normalized, null, 2)}\n\`\`\`\n${BLOCK_END}`;
-  return body ? `${body}\n\n${block}` : block;
+  const { links, ...machine } = normalized;
+  let body = text.replace(BLOCK_RE, '');
+  body = stripRelatedSection(body).trimEnd();
+  const block = `${BLOCK_START}\n\`\`\`ats\n${JSON.stringify(machine, null, 2)}\n\`\`\`\n${BLOCK_END}`;
+  const related = renderRelatedSection(links);
+  const parts = [];
+  if (body) parts.push(body);
+  if (related) parts.push(related);
+  parts.push(block);
+  return parts.join('\n\n');
 }
 
 export function evaluateLifecycle(metadata, { now = new Date(), supersededBy = [] } = {}) {

--- a/packages/core/test/task-context.test.js
+++ b/packages/core/test/task-context.test.js
@@ -70,6 +70,52 @@ test('metadata block round-trips without changing the human-authored body', () =
   assert.equal(parseTaskMetadata(rewritten).intent.why, 'Reduce release risk');
 });
 
+test('links render as a human-readable Related deep-link section, not JSON', () => {
+  const content = writeTaskMetadata('Body paragraph.', {
+    intent: { outcome: 'Ship it' },
+    links: [{
+      type: 'depends-on',
+      projectId: 'p1',
+      taskId: 't1',
+      title: 'Auth spec',
+      url: 'https://ticktick.com/webapp/#p/p1/tasks/t1',
+    }],
+  });
+  // Human-readable Related section, with the deep link clickable.
+  assert.match(content, /## Related\n- depends-on: \[Auth spec\]\(https:\/\/ticktick\.com\/webapp\/#p\/p1\/tasks\/t1\)/);
+  // The machine block no longer carries the link IDs.
+  const block = content.match(/```ats\n([\s\S]*?)\n```/)[1];
+  assert.equal(JSON.parse(block).links, undefined);
+  assert.doesNotMatch(block, /t1/);
+  // Round-trips back into the in-memory link model.
+  const links = parseTaskMetadata(content).links;
+  assert.equal(links.length, 1);
+  assert.deepEqual(
+    [links[0].type, links[0].projectId, links[0].taskId, links[0].title],
+    ['depends-on', 'p1', 't1', 'Auth spec'],
+  );
+});
+
+test('legacy links inside the machine block are read and migrate to Related on write', () => {
+  const legacy = `Body.\n\n<!-- ats:context -->\n\`\`\`ats\n${JSON.stringify({
+    version: 1,
+    intent: { outcome: '', why: '', doneWhen: [], authority: [], constraints: [], approvalRequired: false },
+    lifecycle: { status: 'active' },
+    hierarchy: { kind: 'unspecified' },
+    security: { contentTrust: 'untrusted', allowedActions: [], allowedResources: [], deniedResources: [], approvalRequiredFor: [], approvers: [] },
+    links: [{ type: 'supports', projectId: 'p2', taskId: 't2', title: 'Old plan', url: 'demo://p2/t2' }],
+  }, null, 2)}\n\`\`\`\n<!-- /ats:context -->`;
+  // Back-compat read: legacy block links are still surfaced.
+  const before = parseTaskMetadata(legacy);
+  assert.deepEqual(before.links.map((l) => [l.type, l.projectId, l.taskId]), [['supports', 'p2', 't2']]);
+  // Migrate on write: link moves to Related, machine block drops it.
+  const migrated = writeTaskMetadata(legacy, before);
+  assert.match(migrated, /## Related\n- supports: \[Old plan\]\(demo:\/\/p2\/t2\)/);
+  const block = migrated.match(/```ats\n([\s\S]*?)\n```/)[1];
+  assert.doesNotMatch(block, /t2/);
+  assert.deepEqual(parseTaskMetadata(migrated).links.map((l) => [l.type, l.taskId]), [['supports', 't2']]);
+});
+
 test('malformed managed blocks fail closed', () => {
   assert.throws(
     () => parseTaskMetadata('<!-- ats:context -->\n```ats\n{bad}\n```\n<!-- /ats:context -->'),


### PR DESCRIPTION
## What

Typed cross-task links previously lived inside the `ats:context` JSON block as opaque `{type, projectId, taskId}` entries — a wall of IDs that means nothing to a human reading the task in TickTick/Obsidian. This moves them to a human-readable `## Related` section near the bottom of the task body:

```markdown
## Related
- depends-on: [Auth spec](https://ticktick.com/webapp/#p/demo/tasks/auth-spec)
- supports: [Q3 launch plan](https://ticktick.com/webapp/#p/demo/tasks/q3-plan)
```

One line serves both audiences: a human clicks the deep link (Obsidian-style backlink navigation), the agent parses `type: [title](url)`.

## How

- Serialization-only change in `packages/core/task-context.js` (`parseTaskMetadata` / `writeTaskMetadata` + helpers). The in-memory link model is unchanged, so `ats link`, `ats graph`, `ats context`, hierarchy, and the event stream all keep working untouched.
- `projectId`/`taskId` are recovered from the link URL — the TickTick native deep link (`…/#p/<proj>/tasks/<task>`), or a generic `…/<projectId>/<taskId>` form for other adapters' `urlFor()`. A link written without a url falls back to a parseable `ats://task/<proj>/<task>` ref so it still round-trips.
- The machine block now holds only intent / lifecycle / security / hierarchy.

## Back-compat

Links still inside a legacy JSON block are read (no data loss) and migrate to the `## Related` section on the next write.

## Tests

- Full suite **180/180 pass**, lint clean.
- New: links render as a Related deep-link section (not JSON); machine block carries no link IDs; round-trips into the in-memory model.
- New: legacy JSON-block links are read and migrate to Related on write.
- Existing graph/context/hierarchy/MCP/event tests pass unchanged.

Docs updated in `docs/agent-layer.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)