### PR TITLE
Correct deep links + store machine metadata as OKF-style YAML frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ This adds structure *after* semantic search: retrieval proposes candidates; link
 
 ATS security is a decision point for cooperating clients, not an operating-system sandbox: it cannot intercept unrelated shell, filesystem, or network tools.
 
-The metadata lives in one managed JSON block inside the normal task body, so the same model works through every six-method adapter. [`npm run prove:intent`](examples/intent-layer/) runs a deterministic synthetic proof of the complete path.
+The metadata lives in a YAML frontmatter block (namespaced under `ats:`) at the top of the normal task body, so the same model works through every six-method adapter. [`npm run prove:intent`](examples/intent-layer/) runs a deterministic synthetic proof of the complete path.
 
 **5. Agents can react to state changes without becoming open-ended autonomous runners.**
 `ats events snapshot` establishes a local baseline; `ats events watch --json` emits deterministic `task.created`, `task.updated`, `task.completed`, `task.removed`, `task.unblocked`, `task.validity.changed`, and `task.due.soon` envelopes as newline-delimited JSON. Before advancing the checkpoint, ATS atomically stages those content-free envelopes in a mode-`0600` local spool. `ats events pending` recovers unacknowledged observations after a consumer or output failure; `ats events ack` removes them only after explicit consumer acknowledgement. Stable event IDs deduplicate retries.

--- a/docs/agent-layer.md
+++ b/docs/agent-layer.md
@@ -4,40 +4,48 @@ Retrieval answers: "what looks relevant?" ATS's execution layer adds the informa
 
 ## Portable task metadata
 
-ATS stores one managed JSON block at the end of the normal task body, holding intent, lifecycle, hierarchy, and security. The human-authored markdown remains untouched. Because the block travels through the existing `content` field, every adapter that implements the six-method contract supports it without a backend migration.
+ATS stores its machine metadata — intent, lifecycle, hierarchy, and security — as YAML frontmatter at the top of the task body, namespaced under an `ats:` key so it coexists with any other frontmatter (e.g. an OKF bundle's `title`/`tags`, which ATS preserves verbatim). The human-authored markdown remains untouched. Because the frontmatter travels through the existing `content` field, every adapter that implements the six-method contract supports it without a backend migration.
 
 Typed cross-task links live separately, in a human-readable `## Related` section near the bottom of the body, so a person reading the task in their storage app sees clickable deep links instead of opaque IDs (and the agent reads the same lines).
 
-```json
-{
-  "version": 1,
-  "intent": {
-    "outcome": "Publish a verified release",
-    "why": "Reduce rollout risk",
-    "doneWhen": ["Checks pass", "Rollback is rehearsed"],
-    "authority": ["Approved decision record"],
-    "constraints": ["No production credentials in examples"],
-    "approvalRequired": true
-  },
-  "lifecycle": {
-    "status": "active",
-    "validUntil": "2026-12-31T23:59:59Z"
-  },
-  "hierarchy": {
-    "kind": "task"
-  },
-  "security": {
-    "contentTrust": "untrusted",
-    "allowedActions": ["read", "write"],
-    "allowedResources": ["repo://sample-release/*"],
-    "deniedResources": ["repo://sample-release/private/*"],
-    "approvalRequiredFor": ["write"],
-    "approvers": ["sample-release-owner"]
-  }
-}
+```markdown
+---
+ats:
+  version: 1
+  intent:
+    outcome: Publish a verified release
+    why: Reduce rollout risk
+    doneWhen:
+      - Checks pass
+      - Rollback is rehearsed
+    authority:
+      - Approved decision record
+    constraints:
+      - No production credentials in examples
+    approvalRequired: true
+  lifecycle:
+    status: active
+    validUntil: 2026-12-31T23:59:59Z
+  hierarchy:
+    kind: task
+  security:
+    contentTrust: untrusted
+    allowedActions:
+      - read
+      - write
+    allowedResources:
+      - repo://sample-release/*
+    deniedResources:
+      - repo://sample-release/private/*
+    approvalRequiredFor:
+      - write
+    approvers:
+      - sample-release-owner
+---
+Human-authored task body.
 ```
 
-Malformed managed blocks fail closed: ATS refuses to overwrite them until they are repaired.
+Metadata written in the earlier `<!-- ats:context -->` JSON block is still read for backward compatibility and migrates to frontmatter on the next write. A malformed legacy block fails closed: ATS refuses to overwrite it until it is repaired.
 
 Typed links render in the `## Related` section as `- <type>: [<title>](<deep-link>)`, one bullet per link:
 

--- a/packages/adapter-taskmaster/index.js
+++ b/packages/adapter-taskmaster/index.js
@@ -121,7 +121,12 @@ function scoreTask(task, query) {
 }
 
 function firstDescription(content, title) {
-  const plain = String(content || '').split('<!-- ats:context -->')[0].trim();
+  // Strip ATS metadata before reading the first human line: leading YAML
+  // frontmatter (current format) and the legacy `<!-- ats:context -->` block.
+  const plain = String(content || '')
+    .replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, '')
+    .split('<!-- ats:context -->')[0]
+    .trim();
   return plain.split(/\n\s*\n|\n/).map((line) => line.trim()).find(Boolean) || title;
 }
 

--- a/packages/adapter-ticktick/index.js
+++ b/packages/adapter-ticktick/index.js
@@ -52,8 +52,12 @@ export default {
   updateTask: async (projectId, taskId, patch) =>
     contractTask((await tasks.update(projectId, taskId, patch)).task, { ...patch, projectId }),
 
-  urlFor: ({ projectId, taskId }) =>
-    `https://ticktick.com/webapp/#p/${projectId}/tasks/${taskId}`,
+  urlFor: ({ projectId, taskId }) => {
+    // The Inbox routes under the literal `inbox` slug in the web app, not its
+    // API id ("inbox<userid>"). Task ids must be the full 24-hex form to resolve.
+    const project = /^inbox/i.test(String(projectId)) ? 'inbox' : projectId;
+    return `https://ticktick.com/webapp/#p/${project}/tasks/${taskId}`;
+  },
 
   // --- Optional ---
   searchByQuery: async (query) => (await tasks.search(query)).tasks.map((task) => contractTask(task)),

--- a/packages/cli/parser.js
+++ b/packages/cli/parser.js
@@ -442,7 +442,7 @@ Write an adapter for any store:
 }
 
 export function getAgentLayerHelp(command) {
-  const common = `Portable metadata is stored in a managed JSON block inside the task body,
+  const common = `Portable metadata is stored as YAML frontmatter (under an "ats:" key) at the top of the task body,
 so these commands work through every conforming ATS adapter.`;
   const help = {
     intent: `ats intent - Read or set task intent

--- a/packages/core/task-context.js
+++ b/packages/core/task-context.js
@@ -394,12 +394,17 @@ function taskRef(value, field) {
 }
 
 function linkedRef(adapter, target, type, targetTask, createdAt = new Date().toISOString()) {
+  // Use the resolved task's canonical ids (the adapter contract returns full
+  // ids), not the raw input ref which may be a short id — the deep link must
+  // carry full ids to resolve in the storage app.
+  const projectId = targetTask.projectId || target.projectId;
+  const taskId = targetTask.id || target.taskId;
   return {
     type,
-    projectId: target.projectId,
-    taskId: target.taskId,
+    projectId,
+    taskId,
     title: targetTask.title,
-    url: adapter.urlFor(target),
+    url: adapter.urlFor({ projectId, taskId }),
     createdAt,
   };
 }
@@ -579,35 +584,35 @@ export async function checkTaskAccess(adapter, projectId, taskId, request, optio
 export async function addTaskLink(adapter, source, target, type) {
   if (!LINK_TYPES.includes(type)) throw new Error(`Link type must be one of: ${LINK_TYPES.join(', ')}.`);
   const targetTask = await adapter.getTask(target.projectId, target.taskId);
+  const ref = linkedRef(adapter, target, type, targetTask);
   return updateMetadata(adapter, source.projectId, source.taskId, (metadata) => {
     const duplicate = metadata.links.some((link) =>
-      link.type === type && link.projectId === target.projectId && link.taskId === target.taskId
+      link.type === ref.type && link.projectId === ref.projectId && link.taskId === ref.taskId
     );
     if (duplicate) return metadata;
-    return {
-      ...metadata,
-      links: [
-        ...metadata.links,
-        {
-          type,
-          projectId: target.projectId,
-          taskId: target.taskId,
-          title: targetTask.title,
-          url: adapter.urlFor(target),
-          createdAt: new Date().toISOString(),
-        },
-      ],
-    };
+    return { ...metadata, links: [...metadata.links, ref] };
   });
 }
 
 export async function removeTaskLink(adapter, source, target, type) {
   if (!LINK_TYPES.includes(type)) throw new Error(`Link type must be one of: ${LINK_TYPES.join(', ')}.`);
+  // Resolve the target to its canonical full ids so a short-id argument still
+  // matches links stored with full ids. Fall back to the raw ref if the target
+  // can no longer be fetched (e.g. it was deleted).
+  let projectId = target.projectId;
+  let taskId = target.taskId;
+  try {
+    const targetTask = await adapter.getTask(target.projectId, target.taskId);
+    projectId = targetTask.projectId || projectId;
+    taskId = targetTask.id || taskId;
+  } catch {
+    // keep the ids as given
+  }
   let removed = false;
   const result = await updateMetadata(adapter, source.projectId, source.taskId, (metadata) => ({
     ...metadata,
     links: metadata.links.filter((link) => {
-      const matches = link.type === type && link.projectId === target.projectId && link.taskId === target.taskId;
+      const matches = link.type === type && link.projectId === projectId && link.taskId === taskId;
       if (matches) removed = true;
       return !matches;
     }),

--- a/packages/core/task-context.js
+++ b/packages/core/task-context.js
@@ -256,50 +256,199 @@ function mergeLinks(primary, secondary) {
   return merged;
 }
 
+// --- YAML frontmatter machine block (OKF-style) ------------------------------
+// The machine metadata (intent/lifecycle/security/hierarchy) lives in a YAML
+// frontmatter block at the top of the body, namespaced under an `ats:` key so it
+// coexists with any other frontmatter (e.g. an OKF bundle's title/tags). A
+// zero-dependency emitter/parser covers exactly the shapes ATS writes: nested
+// maps, block sequences of string scalars, booleans, and numbers.
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
+
+function needsYamlQuote(s) {
+  return s === ''
+    || /^\s|\s$/.test(s)
+    || /^[-?:,[\]{}#&*!|>'"%@`]/.test(s)
+    || /:\s|\s#/.test(s)
+    || /[:#]$/.test(s)
+    || /[\n\r\t]/.test(s)
+    || /^(true|false|null|yes|no|on|off|~)$/i.test(s)
+    || /^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/.test(s);
+}
+
+function emitYamlScalar(value) {
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (typeof value === 'number') return String(value);
+  const s = String(value);
+  if (!needsYamlQuote(s)) return s;
+  const escaped = s.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n').replace(/\r/g, '\\r').replace(/\t/g, '\\t');
+  return `"${escaped}"`;
+}
+
+function emitYaml(value, indent) {
+  const pad = '  '.repeat(indent);
+  const out = [];
+  for (const [key, v] of Object.entries(value)) {
+    if (Array.isArray(v)) {
+      if (v.length === 0) { out.push(`${pad}${key}: []`); continue; }
+      out.push(`${pad}${key}:`);
+      const itemPad = '  '.repeat(indent + 1);
+      for (const item of v) out.push(`${itemPad}- ${emitYamlScalar(item)}`);
+    } else if (v && typeof v === 'object') {
+      out.push(`${pad}${key}:`);
+      out.push(emitYaml(v, indent + 1));
+    } else {
+      out.push(`${pad}${key}: ${emitYamlScalar(v)}`);
+    }
+  }
+  return out.join('\n');
+}
+
+function parseYamlScalar(raw) {
+  const s = raw.trim();
+  if (s === '') return '';
+  if (s === '[]') return [];
+  if (s === '{}') return {};
+  if (s.length >= 2 && s[0] === '"' && s[s.length - 1] === '"') {
+    return s.slice(1, -1).replace(/\\(.)/g, (_, c) => ({ n: '\n', r: '\r', t: '\t', '"': '"', '\\': '\\' }[c] ?? c));
+  }
+  if (s === 'true') return true;
+  if (s === 'false') return false;
+  if (s === 'null' || s === '~') return null;
+  if (/^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/.test(s)) return Number(s);
+  return s;
+}
+
+// Parse the controlled YAML subset ATS emits into a JS value.
+function parseYaml(text) {
+  const lines = String(text || '').split('\n').filter((l) => l.trim() !== '' && !/^\s*#/.test(l));
+  let idx = 0;
+  const indentOf = (l) => l.match(/^ */)[0].length;
+  function parseSeq(indent) {
+    const arr = [];
+    while (idx < lines.length) {
+      const line = lines[idx];
+      if (indentOf(line) < indent || !line.trim().startsWith('- ')) break;
+      arr.push(parseYamlScalar(line.trim().slice(2)));
+      idx++;
+    }
+    return arr;
+  }
+  function parseMap(indent) {
+    const obj = {};
+    while (idx < lines.length) {
+      const line = lines[idx];
+      const ind = indentOf(line);
+      if (ind < indent) break;
+      if (ind > indent || line.trim().startsWith('- ')) { idx++; continue; }
+      const m = line.trim().match(/^([^:]+):(?:\s+(.*))?$/);
+      if (!m) { idx++; continue; }
+      const key = m[1].trim();
+      const rest = (m[2] ?? '').trim();
+      idx++;
+      if (rest === '') {
+        const next = lines[idx];
+        if (next && indentOf(next) > indent) {
+          obj[key] = next.trim().startsWith('- ') ? parseSeq(indentOf(next)) : parseMap(indentOf(next));
+        } else {
+          obj[key] = null;
+        }
+      } else {
+        obj[key] = parseYamlScalar(rest);
+      }
+    }
+    return obj;
+  }
+  if (lines.length === 0) return {};
+  return parseMap(indentOf(lines[0]));
+}
+
+// Split frontmatter inner text into ordered top-level key segments (raw lines)
+// so foreign keys are preserved verbatim and only `ats:` is rewritten.
+function splitFrontmatterSegments(inner) {
+  const order = [];
+  const segments = {};
+  let current = null;
+  for (const line of inner.split('\n')) {
+    if (/^[^\s#][^:]*:/.test(line)) {
+      current = line.match(/^([^:]+):/)[1].trim();
+      order.push(current);
+      segments[current] = [line];
+    } else if (current) {
+      segments[current].push(line);
+    }
+  }
+  return { order, segments };
+}
+
 export function parseTaskMetadata(content = '') {
   const text = String(content || '');
-  const matches = [...text.matchAll(BLOCK_RE)];
-  const markerCount = text.split(BLOCK_START).length - 1;
-  const endCount = text.split(BLOCK_END).length - 1;
-  let parsed = {};
-  if (markerCount !== 0 || endCount !== 0) {
-    if (markerCount !== 1 || endCount !== 1 || matches.length !== 1) {
-      throw new Error('Malformed ATS context block. Repair it before ATS writes metadata.');
-    }
-    try {
-      parsed = JSON.parse(matches[0][1]);
-    } catch (err) {
-      throw new Error(`Malformed ATS context JSON: ${err.message}`, { cause: err });
+  let machine = null;
+  let legacyLinks = [];
+
+  // Current format: YAML frontmatter, machine data under the `ats:` key.
+  const fm = text.match(FRONTMATTER_RE);
+  if (fm) {
+    const { segments } = splitFrontmatterSegments(fm[1]);
+    if (segments.ats) machine = parseYaml(segments.ats.slice(1).join('\n'));
+  }
+
+  // Back-compat: legacy `<!-- ats:context -->` JSON block.
+  if (machine === null) {
+    const matches = [...text.matchAll(BLOCK_RE)];
+    const markerCount = text.split(BLOCK_START).length - 1;
+    const endCount = text.split(BLOCK_END).length - 1;
+    if (markerCount !== 0 || endCount !== 0) {
+      if (markerCount !== 1 || endCount !== 1 || matches.length !== 1) {
+        throw new Error('Malformed ATS context block. Repair it before ATS writes metadata.');
+      }
+      try {
+        machine = JSON.parse(matches[0][1]);
+      } catch (err) {
+        throw new Error(`Malformed ATS context JSON: ${err.message}`, { cause: err });
+      }
+      if (machine && typeof machine === 'object' && !Array.isArray(machine)) {
+        legacyLinks = Array.isArray(machine.links) ? machine.links : [];
+      }
     }
   }
-  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    return normalizeTaskMetadata(parsed);
-  }
-  // Links now live in the "## Related" section. Legacy links still inside the
-  // machine block are read for back-compat and migrate to Related on next write.
-  const legacyLinks = Array.isArray(parsed.links) ? parsed.links : [];
+
+  // Links live in the "## Related" section; legacy block links migrate on write.
   const relatedLinks = parseRelatedSection(text);
-  return normalizeTaskMetadata({ ...parsed, links: mergeLinks(relatedLinks, legacyLinks) });
+  if (machine !== null && (typeof machine !== 'object' || Array.isArray(machine))) {
+    return normalizeTaskMetadata(machine);
+  }
+  return normalizeTaskMetadata({ ...(machine || {}), links: mergeLinks(relatedLinks, legacyLinks) });
 }
 
 export function writeTaskMetadata(content = '', metadata = {}) {
   const text = String(content || '');
-  const current = [...text.matchAll(BLOCK_RE)];
+  // Guard a corrupted legacy block so we never silently overwrite it.
   const markerCount = text.split(BLOCK_START).length - 1;
   const endCount = text.split(BLOCK_END).length - 1;
-  if ((markerCount > 0 || endCount > 0) && (markerCount !== 1 || endCount !== 1 || current.length !== 1)) {
+  const blockMatches = [...text.matchAll(BLOCK_RE)];
+  if ((markerCount > 0 || endCount > 0) && (markerCount !== 1 || endCount !== 1 || blockMatches.length !== 1)) {
     throw new Error('Malformed ATS context block. Repair it before ATS writes metadata.');
   }
   const normalized = normalizeTaskMetadata(metadata);
   const { links, ...machine } = normalized;
+
+  // Strip the legacy block, any existing frontmatter (preserving foreign keys),
+  // and the Related section, then rebuild: frontmatter, body, Related.
   let body = text.replace(BLOCK_RE, '');
+  const foreign = [];
+  const fm = body.match(FRONTMATTER_RE);
+  if (fm) {
+    const { order, segments } = splitFrontmatterSegments(fm[1]);
+    for (const key of order) if (key !== 'ats') foreign.push(segments[key].join('\n'));
+    body = body.slice(fm[0].length);
+  }
   body = stripRelatedSection(body).trimEnd();
-  const block = `${BLOCK_START}\n\`\`\`ats\n${JSON.stringify(machine, null, 2)}\n\`\`\`\n${BLOCK_END}`;
+
+  const frontmatter = `---\n${[...foreign, `ats:\n${emitYaml(machine, 1)}`].join('\n')}\n---`;
   const related = renderRelatedSection(links);
-  const parts = [];
+  const parts = [frontmatter];
   if (body) parts.push(body);
   if (related) parts.push(related);
-  parts.push(block);
   return parts.join('\n\n');
 }
 

--- a/packages/core/test/task-context.test.js
+++ b/packages/core/test/task-context.test.js
@@ -59,7 +59,8 @@ test('metadata block round-trips without changing the human-authored body', () =
   const content = writeTaskMetadata('Keep this paragraph.\n', {
     intent: { outcome: 'Ship a verified release', doneWhen: ['Smoke test passes'] },
   });
-  assert.match(content, /^Keep this paragraph\.\n\n<!-- ats:context -->/);
+  assert.match(content, /^---\nats:\n/);
+  assert.match(content, /\n---\n\nKeep this paragraph\./);
   const metadata = parseTaskMetadata(content);
   assert.equal(metadata.intent.outcome, 'Ship a verified release');
   assert.deepEqual(metadata.intent.doneWhen, ['Smoke test passes']);
@@ -83,10 +84,10 @@ test('links render as a human-readable Related deep-link section, not JSON', () 
   });
   // Human-readable Related section, with the deep link clickable.
   assert.match(content, /## Related\n- depends-on: \[Auth spec\]\(https:\/\/ticktick\.com\/webapp\/#p\/p1\/tasks\/t1\)/);
-  // The machine block no longer carries the link IDs.
-  const block = content.match(/```ats\n([\s\S]*?)\n```/)[1];
-  assert.equal(JSON.parse(block).links, undefined);
-  assert.doesNotMatch(block, /t1/);
+  // The YAML frontmatter machine block carries no link IDs.
+  const fmInner = content.match(/^---\n([\s\S]*?)\n---/)[1];
+  assert.match(fmInner, /ats:/);
+  assert.doesNotMatch(fmInner, /t1/);
   // Round-trips back into the in-memory link model.
   const links = parseTaskMetadata(content).links;
   assert.equal(links.length, 1);
@@ -148,10 +149,56 @@ test('legacy links inside the machine block are read and migrate to Related on w
   assert.deepEqual(before.links.map((l) => [l.type, l.projectId, l.taskId]), [['supports', 'p2', 't2']]);
   // Migrate on write: link moves to Related, machine block drops it.
   const migrated = writeTaskMetadata(legacy, before);
+  assert.match(migrated, /^---\nats:\n/);
   assert.match(migrated, /## Related\n- supports: \[Old plan\]\(demo:\/\/p2\/t2\)/);
-  const block = migrated.match(/```ats\n([\s\S]*?)\n```/)[1];
-  assert.doesNotMatch(block, /t2/);
+  const fmInner = migrated.match(/^---\n([\s\S]*?)\n---/)[1];
+  assert.doesNotMatch(fmInner, /t2/);
   assert.deepEqual(parseTaskMetadata(migrated).links.map((l) => [l.type, l.taskId]), [['supports', 't2']]);
+});
+
+test('the YAML frontmatter machine block round-trips structured fields and special characters', () => {
+  const content = writeTaskMetadata('Body.', {
+    intent: {
+      outcome: 'Ship: a verified release',
+      why: 'Reduce "rollout" risk',
+      doneWhen: ['Checks pass', 'Rollback rehearsed'],
+      authority: ['Approved decision'],
+      constraints: ['No prod creds'],
+      approvalRequired: true,
+    },
+    lifecycle: { status: 'active', validUntil: '2026-12-31' },
+    hierarchy: { kind: 'task' },
+    security: {
+      contentTrust: 'mixed',
+      allowedActions: ['read', 'write'],
+      allowedResources: ['repo://demo/*'],
+      deniedResources: ['repo://demo/private/*'],
+      approvalRequiredFor: ['write'],
+      approvers: ['owner@example.com'],
+    },
+  });
+  assert.match(content, /^---\nats:\n/);
+  const back = parseTaskMetadata(content);
+  assert.equal(back.intent.outcome, 'Ship: a verified release');
+  assert.equal(back.intent.why, 'Reduce "rollout" risk');
+  assert.deepEqual(back.intent.doneWhen, ['Checks pass', 'Rollback rehearsed']);
+  assert.equal(back.intent.approvalRequired, true);
+  assert.equal(back.lifecycle.validUntil, '2026-12-31');
+  assert.equal(back.hierarchy.kind, 'task');
+  assert.equal(back.security.contentTrust, 'mixed');
+  assert.deepEqual(back.security.allowedResources, ['repo://demo/*']);
+  assert.deepEqual(back.security.deniedResources, ['repo://demo/private/*']);
+  assert.deepEqual(back.security.approvers, ['owner@example.com']);
+});
+
+test('foreign frontmatter keys are preserved when ATS rewrites its block', () => {
+  const content = '---\ntitle: My Note\ntags:\n  - alpha\n  - beta\n---\nBody text.';
+  const out = writeTaskMetadata(content, { intent: { outcome: 'Do the thing' } });
+  assert.match(out, /title: My Note/);
+  assert.match(out, /- alpha/);
+  assert.match(out, /\nats:\n/);
+  assert.match(out, /Body text\./);
+  assert.equal(parseTaskMetadata(out).intent.outcome, 'Do the thing');
 });
 
 test('malformed managed blocks fail closed', () => {

--- a/packages/core/test/task-context.test.js
+++ b/packages/core/test/task-context.test.js
@@ -96,6 +96,24 @@ test('links render as a human-readable Related deep-link section, not JSON', () 
   );
 });
 
+test('a link uses the target\'s full ids and the adapter deep-link form', async () => {
+  const store = {
+    src: { id: 'srcfull0000000000000000', projectId: 'inbox127571151', title: 'Source', content: '' },
+    tgt: { id: '6a3278c68f0825a68248863f', projectId: 'inbox127571151', title: 'Target', content: '' },
+  };
+  const adapter = {
+    getTask: async (_p, t) => store[t],
+    updateTask: async (_p, t, patch) => { store[t] = { ...store[t], ...patch }; return store[t]; },
+    urlFor: ({ projectId, taskId }) =>
+      `https://ticktick.com/webapp/#p/${/^inbox/i.test(projectId) ? 'inbox' : projectId}/tasks/${taskId}`,
+  };
+  // Add the link using a SHORT target id; it must store the full id + inbox slug.
+  await addTaskLink(adapter, { projectId: 'inbox127571151', taskId: 'src' }, { projectId: 'inbox127571151', taskId: 'tgt' }, 'depends-on');
+  const link = parseTaskMetadata(store.src.content).links[0];
+  assert.equal(link.taskId, '6a3278c68f0825a68248863f');
+  assert.equal(link.url, 'https://ticktick.com/webapp/#p/inbox/tasks/6a3278c68f0825a68248863f');
+});
+
 test('a link title containing brackets stays well-formed and round-trips', () => {
   const content = writeTaskMetadata('Body.', {
     links: [{


### PR DESCRIPTION
Two changes to the task-body format, both surfaced while verifying the 0.7.x Related feature on a live TickTick task.

## 1. Correct deep links (was: 404)
The Related deep link used the **short** task id and the Inbox's API id (`inbox<userid>`), so it didn't resolve in the web app. Now:
- Build the link from the resolved target task's canonical **full** ids (the adapter contract already returns them).
- Route the Inbox under its literal `inbox` slug.
- `removeTaskLink` resolves a short-id argument to full ids so it still matches stored links.

Result: `https://ticktick.com/webapp/#p/inbox/tasks/<fullId>` — clickable.

## 2. Machine metadata → OKF-style YAML frontmatter
Replaces the `<!-- ats:context -->` JSON block with YAML frontmatter at the top of the body, namespaced under an `ats:` key:

```markdown
---
ats:
  version: 1
  intent:
    outcome: Ship a verified release
    doneWhen:
      - Smoke test passes
  lifecycle:
    status: active
  hierarchy:
    kind: task
  security:
    contentTrust: untrusted
---
Human body.

## Related
- depends-on: [Spec](https://ticktick.com/webapp/#p/inbox/tasks/<fullId>)
```

- Zero-dependency YAML emitter/parser for the shapes ATS writes (nested maps, block sequences of string scalars, booleans, numbers); conditional quoting for YAML-significant characters.
- Foreign frontmatter (e.g. an OKF bundle's `title`/`tags`) is preserved verbatim.
- Legacy JSON blocks are still read and migrate to frontmatter on the next write.
- Taskmaster's first-line description strip now skips leading frontmatter.

## Tests
Full suite **184/184**, lint clean. New: full-metadata round-trip with special characters/globs/dates; foreign-frontmatter preservation; full-id + inbox-slug link URLs. Docs (`docs/agent-layer.md`, README, CLI help) updated.