### PR TITLE
task-context: emit only non-default fields in ats frontmatter (shrink the block)

### DIFF
--- a/docs/agent-layer.md
+++ b/docs/agent-layer.md
@@ -45,6 +45,8 @@ ats:
 Human-authored task body.
 ```
 
+Only fields that differ from their defaults are written, so the block stays small. Empty lists, `status: active`, `kind: unspecified`, `contentTrust: untrusted`, and `approvalRequired: false` are omitted; a task with no ATS metadata and only links carries no frontmatter at all — just its body and `## Related` section.
+
 Metadata written in the earlier `<!-- ats:context -->` JSON block is still read for backward compatibility and migrates to frontmatter on the next write. A malformed legacy block fails closed: ATS refuses to overwrite it until it is repaired.
 
 Typed links render in the `## Related` section as `- <type>: [<title>](<deep-link>)`, one bullet per link:

--- a/packages/core/task-context.js
+++ b/packages/core/task-context.js
@@ -380,6 +380,40 @@ function splitFrontmatterSegments(inner) {
   return { order, segments };
 }
 
+// Reduce normalized metadata to only the fields that differ from their
+// defaults, so the frontmatter stays small. Returns {} when nothing meaningful
+// is set — the caller then omits the `ats:` block (and frontmatter) entirely.
+function minimalMachine(m) {
+  const intent = {};
+  if (m.intent.outcome) intent.outcome = m.intent.outcome;
+  if (m.intent.why) intent.why = m.intent.why;
+  if (m.intent.doneWhen.length) intent.doneWhen = m.intent.doneWhen;
+  if (m.intent.authority.length) intent.authority = m.intent.authority;
+  if (m.intent.constraints.length) intent.constraints = m.intent.constraints;
+  if (m.intent.approvalRequired) intent.approvalRequired = true;
+
+  const lifecycle = {};
+  if (m.lifecycle.status && m.lifecycle.status !== 'active') lifecycle.status = m.lifecycle.status;
+  if (m.lifecycle.validFrom) lifecycle.validFrom = m.lifecycle.validFrom;
+  if (m.lifecycle.validUntil) lifecycle.validUntil = m.lifecycle.validUntil;
+
+  const security = {};
+  if (m.security.contentTrust && m.security.contentTrust !== 'untrusted') security.contentTrust = m.security.contentTrust;
+  if (m.security.allowedActions.length) security.allowedActions = m.security.allowedActions;
+  if (m.security.allowedResources.length) security.allowedResources = m.security.allowedResources;
+  if (m.security.deniedResources.length) security.deniedResources = m.security.deniedResources;
+  if (m.security.approvalRequiredFor.length) security.approvalRequiredFor = m.security.approvalRequiredFor;
+  if (m.security.approvers.length) security.approvers = m.security.approvers;
+
+  const out = {};
+  if (Object.keys(intent).length) out.intent = intent;
+  if (Object.keys(lifecycle).length) out.lifecycle = lifecycle;
+  if (m.hierarchy.kind && m.hierarchy.kind !== 'unspecified') out.hierarchy = { kind: m.hierarchy.kind };
+  if (Object.keys(security).length) out.security = security;
+  if (Object.keys(out).length === 0) return {};
+  return { version: TASK_CONTEXT_VERSION, ...out };
+}
+
 export function parseTaskMetadata(content = '') {
   const text = String(content || '');
   let machine = null;
@@ -430,7 +464,8 @@ export function writeTaskMetadata(content = '', metadata = {}) {
     throw new Error('Malformed ATS context block. Repair it before ATS writes metadata.');
   }
   const normalized = normalizeTaskMetadata(metadata);
-  const { links, ...machine } = normalized;
+  const { links } = normalized;
+  const minimal = minimalMachine(normalized);
 
   // Strip the legacy block, any existing frontmatter (preserving foreign keys),
   // and the Related section, then rebuild: frontmatter, body, Related.
@@ -444,9 +479,14 @@ export function writeTaskMetadata(content = '', metadata = {}) {
   }
   body = stripRelatedSection(body).trimEnd();
 
-  const frontmatter = `---\n${[...foreign, `ats:\n${emitYaml(machine, 1)}`].join('\n')}\n---`;
+  // Only emit frontmatter when there is foreign frontmatter to preserve or
+  // non-default ATS metadata to record. A link-only task carries none.
+  const fmParts = [...foreign];
+  if (Object.keys(minimal).length) fmParts.push(`ats:\n${emitYaml(minimal, 1)}`);
+  const frontmatter = fmParts.length ? `---\n${fmParts.join('\n')}\n---` : '';
   const related = renderRelatedSection(links);
-  const parts = [frontmatter];
+  const parts = [];
+  if (frontmatter) parts.push(frontmatter);
   if (body) parts.push(body);
   if (related) parts.push(related);
   return parts.join('\n\n');

--- a/packages/core/test/task-context.test.js
+++ b/packages/core/test/task-context.test.js
@@ -149,10 +149,10 @@ test('legacy links inside the machine block are read and migrate to Related on w
   assert.deepEqual(before.links.map((l) => [l.type, l.projectId, l.taskId]), [['supports', 'p2', 't2']]);
   // Migrate on write: link moves to Related, machine block drops it.
   const migrated = writeTaskMetadata(legacy, before);
-  assert.match(migrated, /^---\nats:\n/);
+  // Link-only metadata carries nothing non-default, so no frontmatter is written;
+  // the legacy JSON block is gone and the link lives in the Related section.
+  assert.doesNotMatch(migrated, /<!-- ats:context -->/);
   assert.match(migrated, /## Related\n- supports: \[Old plan\]\(demo:\/\/p2\/t2\)/);
-  const fmInner = migrated.match(/^---\n([\s\S]*?)\n---/)[1];
-  assert.doesNotMatch(fmInner, /t2/);
   assert.deepEqual(parseTaskMetadata(migrated).links.map((l) => [l.type, l.taskId]), [['supports', 't2']]);
 });
 


### PR DESCRIPTION
The YAML frontmatter wrote every field, including empty lists, empty strings, and default enums — ~25 lines for a task with almost no metadata.

Now ATS emits only fields that differ from their defaults, and omits the `ats:` block (and the frontmatter delimiters) entirely when nothing meaningful is set. A link-only task collapses to just its body and the `## Related` section.

Examples:
- Link only → no frontmatter, just `## Related`.
- `intent.outcome` + `doneWhen` + `kind: task` → a ~6-line `ats:` block, nothing else.

Defaults omitted: empty lists, `status: active`, `kind: unspecified`, `contentTrust: untrusted`, `approvalRequired: false`.

Round-trip is unchanged: missing fields are filled from defaults on read. Full suite 184/184, lint clean. Docs updated.