### PR TITLE
Add Nomic query and document embedding prefixes

### DIFF
--- a/packages/adapter-ticktick/README.md
+++ b/packages/adapter-ticktick/README.md
@@ -28,6 +28,20 @@ docker exec ollama ollama pull nomic-embed-text
 ats sync vector
 ```
 
+Nomic retrieval prefixes are opt-in because stored documents and queries must
+be migrated together. Build a separate collection and metadata manifest before
+enabling them:
+
+```bash
+ATS_TICKTICK_VECTOR_COLLECTION=ticktick_tasks_nomic_prefixed \
+ATS_TICKTICK_VECTOR_META="$HOME/.local/share/ats/vector-index-meta-nomic-prefixed.json" \
+ATS_TICKTICK_NOMIC_PREFIXES=1 \
+ats sync vector --full
+```
+
+Use the same three variables for subsequent search commands. Do not enable only
+the query prefix against an existing unprefixed collection.
+
 ## What this adapter implements
 
 All six required methods of the ATS adapter contract:

--- a/packages/adapter-ticktick/embedding.js
+++ b/packages/adapter-ticktick/embedding.js
@@ -23,7 +23,8 @@ import { homedir } from 'node:os';
 const QDRANT_URL = process.env.QDRANT_URL || 'http://localhost:6333';
 const OLLAMA_URL = process.env.OLLAMA_URL || 'http://localhost:11434';
 const EMBEDDING_MODEL = process.env.EMBEDDING_MODEL || 'nomic-embed-text';
-const COLLECTION_NAME = 'ticktick_tasks';
+const COLLECTION_NAME = process.env.ATS_TICKTICK_VECTOR_COLLECTION || 'ticktick_tasks';
+const USE_NOMIC_PREFIXES = process.env.ATS_TICKTICK_NOMIC_PREFIXES === '1';
 const EMBEDDING_DIMENSION = 768;
 const BATCH_SIZE = 10;
 const BATCH_DELAY_MS = 100;
@@ -36,7 +37,7 @@ const DATA_BASE = process.env.XDG_DATA_HOME || join(homedir(), '.local', 'share'
 const _ATS_META_DIR = join(DATA_BASE, 'ats');
 const _LEGACY_META_DIR = join(DATA_BASE, 'akb');
 const META_DIR = (!existsSync(_ATS_META_DIR) && existsSync(_LEGACY_META_DIR)) ? _LEGACY_META_DIR : _ATS_META_DIR;
-const META_PATH = join(META_DIR, 'vector-index-meta.json');
+const META_PATH = process.env.ATS_TICKTICK_VECTOR_META || join(META_DIR, 'vector-index-meta.json');
 
 // --- HTTP helpers ---
 
@@ -61,8 +62,22 @@ async function httpJson(url, method = 'GET', body = undefined, timeoutMs = 30000
 
 // --- Embedding ---
 
-async function getEmbedding(text) {
-  const truncated = text.slice(0, 8000);
+export function embeddingInput(text, inputType = 'document', options = {}) {
+  const model = options.model || EMBEDDING_MODEL;
+  const useNomicPrefixes = options.useNomicPrefixes ?? USE_NOMIC_PREFIXES;
+  if (!useNomicPrefixes || !model.startsWith('nomic-embed-text')) return text;
+  const prefix = inputType === 'query' ? 'search_query: ' : 'search_document: ';
+  return `${prefix}${text}`;
+}
+
+export function truncateText(text, maxCharacters, suffix = '') {
+  const characters = Array.from(text);
+  if (characters.length <= maxCharacters) return text;
+  return characters.slice(0, maxCharacters).join('') + suffix;
+}
+
+async function getEmbedding(text, inputType = 'document') {
+  const truncated = truncateText(embeddingInput(text, inputType), 8000);
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     try {
       const data = await httpJson(
@@ -259,7 +274,7 @@ export async function sync(fetchAllTasks, options = {}) {
     for (const { task, hash, isNew } of batch) {
       try {
         const text = taskToText(task);
-        const vector = await getEmbedding(text);
+        const vector = await getEmbedding(text, 'document');
         points.push({
           id: hashId(task.id),
           vector,
@@ -309,7 +324,7 @@ export async function search(query, options = {}) {
   const health = await checkHealth();
   if (!health.available) throw new Error(health.reason);
 
-  const vector = await getEmbedding(query);
+  const vector = await getEmbedding(query, 'query');
 
   const searchBody = {
     vector,
@@ -563,9 +578,21 @@ export async function indexStats() {
       available: true,
       vectorCount: info.result?.points_count || 0,
       lastSync: meta.lastSync,
+      collection: COLLECTION_NAME,
+      embeddingModel: EMBEDDING_MODEL,
+      nomicPrefixes: USE_NOMIC_PREFIXES,
+      metaPath: META_PATH,
     };
   } catch {
-    return { available: true, vectorCount: 0, lastSync: null };
+    return {
+      available: true,
+      vectorCount: 0,
+      lastSync: null,
+      collection: COLLECTION_NAME,
+      embeddingModel: EMBEDDING_MODEL,
+      nomicPrefixes: USE_NOMIC_PREFIXES,
+      metaPath: META_PATH,
+    };
   }
 }
 

--- a/packages/adapter-ticktick/test/embedding.test.js
+++ b/packages/adapter-ticktick/test/embedding.test.js
@@ -1,6 +1,41 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { dedupeRankedByTaskId, hashId } from '../embedding.js';
+import { dedupeRankedByTaskId, embeddingInput, hashId, truncateText } from '../embedding.js';
+
+test('Nomic prefixes distinguish stored documents from search queries', () => {
+  const options = { model: 'nomic-embed-text', useNomicPrefixes: true };
+  assert.equal(embeddingInput('deploy guide', 'document', options), 'search_document: deploy guide');
+  assert.equal(embeddingInput('how do I deploy?', 'query', options), 'search_query: how do I deploy?');
+});
+
+test('embedding input stays unchanged when Nomic prefixes are disabled', () => {
+  assert.equal(
+    embeddingInput('deploy guide', 'document', {
+      model: 'nomic-embed-text',
+      useNomicPrefixes: false,
+    }),
+    'deploy guide'
+  );
+});
+
+test('Nomic prefixes are not applied to another embedding model', () => {
+  assert.equal(
+    embeddingInput('deploy guide', 'document', {
+      model: 'other-embedder',
+      useNomicPrefixes: true,
+    }),
+    'deploy guide'
+  );
+});
+
+test('truncation preserves an astral Unicode character at the boundary', () => {
+  const text = `${'a'.repeat(499)}🔷Permanent Notes`;
+  const truncated = truncateText(text, 500);
+
+  assert.equal(Array.from(truncated).length, 500);
+  assert.equal(Array.from(truncated).at(-1), '🔷');
+  assert.equal(truncated.codePointAt(truncated.length - 2), 0x1f537);
+});
 
 test('semantic results keep the highest-ranked point for each task ID', () => {
   const ranked = [

--- a/packages/core/bench/README.md
+++ b/packages/core/bench/README.md
@@ -42,6 +42,9 @@ One JSON object per line:
 }
 ```
 
+For an any-of-N answer, replace `gold_task_id` with a non-empty
+`gold_task_ids` array. The runner preserves that array for the scorer.
+
 **`tags`** — free-form strings used as buckets in the score report.
 Suggested taxonomy:
 
@@ -93,6 +96,21 @@ const METHODS = {
 ```
 
 The scorer auto-discovers any method that has results in `results/`.
+
+## Side-by-side variants
+
+Use `--variant` when the same retrieval method is evaluated against different
+model, collection, or prompt configurations. The variant is appended to the
+result method name, so one run cannot overwrite another run from the same day.
+
+```bash
+ats bench run --method=semantic --variant=baseline
+ATS_TICKTICK_VECTOR_COLLECTION=ticktick_tasks_nomic_prefixed \
+ATS_TICKTICK_VECTOR_META="$HOME/.local/share/ats/vector-index-meta-nomic-prefixed.json" \
+ATS_TICKTICK_NOMIC_PREFIXES=1 \
+ats bench run --method=semantic --variant=nomic-prefixed
+ats bench score
+```
 
 ## Workflow progress
 

--- a/packages/core/bench/run.js
+++ b/packages/core/bench/run.js
@@ -8,6 +8,7 @@
  *   node bench/run.js --method=semantic     # one method
  *   node bench/run.js --questions=path.jsonl
  *   node bench/run.js --top=10              # capture top 10 instead of 5
+ *   node bench/run.js --variant=baseline    # keep A/B result files separate
  *
  * To add a method: edit METHODS below.
  */
@@ -23,6 +24,7 @@ const args = parseArgs(process.argv.slice(2));
 const questionsPath = args.questions || path.join(__dirname, 'data', 'questions.jsonl');
 const top = Number(args.top) || 5;
 const onlyMethod = args.method || null;
+const variant = sanitizeVariant(args.variant || process.env.ATS_BENCH_VARIANT || '');
 const resultsDir = path.resolve(args.results || path.join(__dirname, 'results'));
 const cli = process.env.ATS_BENCH_CLI || 'ats';
 
@@ -159,6 +161,13 @@ function todayStamp() {
   return new Date().toISOString().slice(0, 10);
 }
 
+function sanitizeVariant(value) {
+  if (!value) return '';
+  const sanitized = String(value).toLowerCase().replace(/[^a-z0-9-]+/g, '-').replace(/^-|-$/g, '');
+  if (!sanitized) throw new Error(`invalid benchmark variant: ${value}`);
+  return sanitized;
+}
+
 function readQuestions(p) {
   if (!fs.existsSync(p)) {
     console.error(`questions file missing: ${p}`);
@@ -166,7 +175,7 @@ function readQuestions(p) {
     process.exit(2);
   }
   const lines = fs.readFileSync(p, 'utf8').split('\n').filter((l) => l.trim() && !l.startsWith('//'));
-  return lines.map((l, i) => {
+  const questions = lines.map((l, i) => {
     try {
       return JSON.parse(l);
     } catch (err) {
@@ -174,6 +183,19 @@ function readQuestions(p) {
       process.exit(2);
     }
   });
+  const seen = new Set();
+  for (const q of questions) {
+    if (!q.id || !q.question || (!q.gold_task_id && !q.gold_task_ids)) {
+      console.error(`invalid question schema for ${q.id || '<missing id>'}`);
+      process.exit(2);
+    }
+    if (seen.has(q.id)) {
+      console.error(`duplicate question id: ${q.id}`);
+      process.exit(2);
+    }
+    seen.add(q.id);
+  }
+  return questions;
 }
 
 function runAll() {
@@ -191,20 +213,22 @@ function runAll() {
       console.error(`unknown method: ${m}`);
       continue;
     }
-    const outPath = path.join(resultsDir, `${m}-${date}.jsonl`);
+    const outputMethod = variant ? `${m}-${variant}` : m;
+    const outPath = path.join(resultsDir, `${outputMethod}-${date}.jsonl`);
     const out = fs.openSync(outPath, 'w');
-    console.log(`[${m}] ${METHODS[m].description}`);
+    console.log(`[${outputMethod}] ${METHODS[m].description}`);
     let ok = 0;
     let fail = 0;
     for (const q of questions) {
       process.stdout.write(`  ${q.id}: ${q.question.slice(0, 60)}... `);
       const result = METHODS[m].run(q.question);
       const line = JSON.stringify({
-        method: m,
+        method: outputMethod,
         date,
         id: q.id,
         question: q.question,
         gold_task_id: q.gold_task_id,
+        gold_task_ids: q.gold_task_ids,
         gold_project_id: q.gold_project_id,
         tags: q.tags || [],
         top: result.top || [],
@@ -216,7 +240,8 @@ function runAll() {
         console.log(`ERR: ${result.error}`);
       } else {
         ok++;
-        const goldIdx = (result.top || []).findIndex((r) => r.id === q.gold_task_id);
+        const golds = q.gold_task_ids || [q.gold_task_id];
+        const goldIdx = (result.top || []).findIndex((r) => golds.includes(r.id));
         const rankStr = goldIdx === -1 ? 'miss' : `rank ${goldIdx + 1}`;
         console.log(rankStr);
       }


### PR DESCRIPTION
## What changed

- Add opt-in Nomic `search_query:` and `search_document:` embedding prefixes.
- Add separate vector collection and metadata-path configuration for safe side-by-side reindexing.
- Make embedding truncation Unicode-safe.
- Add benchmark variants and any-of-N gold task support for A/B evaluation.

## Why

Nomic retrieval expects `search_document:` for indexed documents and `search_query:` for queries. The adapter previously embedded both without task prefixes, so the recommended asymmetric retrieval mode was unavailable. Prefixes must be enabled with a separately reindexed collection.

## Measured impact

On a private 25-question, 1,900-task benchmark:

- Semantic: hit@1 84% -> 88%, recall@5 92% -> 96%, MRR 0.88 -> 0.92.
- Hybrid/find: hit@1 84% -> 88%, recall@5 96% -> 100%, MRR 0.89 -> 0.93.

No private benchmark data is included.

## Validation

- `npm test`: lint, PII, claims, 225 tests, and all proof suites passed.
- Focused adapter test suite: 8/8 passed.
- Synthetic side-by-side benchmark variant test passed, including any-of-N gold task IDs.
