### PR TITLE
v0.10: reliable memory — degraded transparency, reranking, usage observability, dedup, reactive auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 
 # Changelog
 
+## 0.10.0 - Degraded-retrieval transparency, reranking, usage observability, dedup, reactive auth
+
+Unreleased.
+
+- **Degraded-retrieval transparency.** `find` now tells the caller when a result is partial instead of silently serving a subset. A dropped corpus source (a composite child backend that errored, or a single project that failed to list) and a retrieval branch that errored or timed out roll up into a top-level `degraded` boolean plus a `warnings` list and `corpus.sourcesFailed`; a known-partial corpus is no longer cached as if it were complete. The composite adapter records which child it dropped instead of filtering it away silently.
+- **Optional reranking.** `find` gains a second-stage reranker over the RRF-fused pool: `rerank: true` uses a built-in, dependency-free lexical scorer (query-term coverage with title/phrase weighting), or pass a function to plug a cross-encoder/LLM. It fuses a wider `rerankDepth` pool then trims to `limit`; a failing reranker degrades to the fused order (surfaced via `degraded`). CLI: `ats find --rerank [--rerank-depth N]`.
+- **Usage observability.** Retrieval calls now log `durationMs`, and `ats usage` reports per-tool volume, empty/error/degraded rates, latency (avg + p95), re-query pairs, and top queries (`--json` for machine output, markdown otherwise). The analysis lives in one core `summarize()` shared by the CLI and the `bench/analyze-usage` renderer, so both agree by construction.
+- **Duplicate / contradiction detection.** `ats dedup` scans the corpus for near-duplicate task clusters (dependency-free Jaccard over title + content + tags, transitively grouped) and flags field-level disagreements (status/priority/due) within a cluster as potential contradictions — the candidates you then link with `conflicts-with` / `supersedes`. Detection only; it never edits.
+- **Reactive token refresh.** The TickTick adapter now refreshes its OAuth token and retries once on a `401` — the revoked / invalidated-early / wrong-stored-expiry cases the proactive clock-based refresh misses — then surfaces an actionable "run `ats auth login`" if the refresh does not resolve it.
+
 ## 0.9.0 - Undo, forward links, path-traversal hardening, broader MCP clients
 
 Released 2026-07-03.

--- a/packages/adapter-composite/index.js
+++ b/packages/adapter-composite/index.js
@@ -90,13 +90,23 @@ export function buildAdapter(getChildren) {
     async bulkFetch() {
       const children = await getChildren();
       adapter.__children = children; // cache for synchronous urlFor()
-      const corpora = await settle(
-        children.map((c) =>
-          (typeof c.adapter.bulkFetch === 'function'
-            ? c.adapter.bulkFetch()
-            : fallbackFetch(c.adapter)
-          ).then((tasks) => (tasks || []).map((t) => remapTask(c.key, t)))
-        )
+      adapter.__fetchWarnings = [];
+      const corpora = await Promise.all(
+        children.map(async (c) => {
+          try {
+            const tasks = typeof c.adapter.bulkFetch === 'function'
+              ? await c.adapter.bulkFetch()
+              : await fallbackFetch(c.adapter);
+            return (tasks || []).map((t) => remapTask(c.key, t));
+          } catch (e) {
+            // A child backend that fails must not vanish from the fused corpus
+            // without a trace — record it (keyed by backend) so the retrieval
+            // layer can flag the result as partial rather than serve a silent
+            // subset of the user's memory.
+            adapter.__fetchWarnings.push({ source: c.key, error: e.message });
+            return [];
+          }
+        })
       );
       return corpora.flat();
     },
@@ -146,6 +156,7 @@ export function buildAdapter(getChildren) {
     },
 
     __children: [],
+    __fetchWarnings: [],
   };
 
   return adapter;

--- a/packages/adapter-ticktick/api.js
+++ b/packages/adapter-ticktick/api.js
@@ -254,17 +254,17 @@ export async function refreshAccessToken(config, refreshToken, deps = {}) {
 /**
  * Get a valid access token, refreshing if needed
  */
-export async function getValidAccessToken() {
-  const config = await loadConfig();
-  const tokens = await loadTokens();
+export async function getValidAccessToken(deps = {}) {
+  const config = await loadConfig(deps);
+  const tokens = await loadTokens(deps);
 
   if (!tokens) {
     throw new Error('Not authenticated. Run: ats auth login');
   }
 
   if (isTokenExpired(tokens)) {
-    const newTokens = await refreshAccessToken(config, tokens.refreshToken);
-    await saveTokens(newTokens);
+    const newTokens = await refreshAccessToken(config, tokens.refreshToken, deps);
+    await saveTokens(newTokens, deps);
     return newTokens.accessToken;
   }
 
@@ -272,32 +272,59 @@ export async function getValidAccessToken() {
 }
 
 /**
+ * Force a token refresh regardless of the stored expiry, persist it, and return
+ * the fresh access token. Used to recover from a 401 on a token the clock-based
+ * check still considered valid — revoked, invalidated early, or a wrong stored
+ * expiry. Returns null when there is no refresh token to try.
+ */
+async function forceRefresh(config, deps = {}) {
+  const tokens = await loadTokens(deps);
+  if (!tokens || !tokens.refreshToken) return null;
+  const newTokens = await refreshAccessToken(config, tokens.refreshToken, deps);
+  await saveTokens(newTokens, deps);
+  return newTokens.accessToken;
+}
+
+/**
  * Make an API request
  */
 export async function apiRequest(method, path, body = undefined, deps = {}) {
   const { fetchFn = fetch } = deps;
-  const config = await loadConfig();
-  const accessToken = await getValidAccessToken();
+  const config = await loadConfig(deps);
   const baseUrl = API_URLS[validateRegion(config.region)];
   const url = `${baseUrl}${path}`;
 
-  const headers = {
-    Authorization: `Bearer ${accessToken}`,
-    Accept: 'application/json',
+  const doFetch = (accessToken) => {
+    const headers = {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: 'application/json',
+    };
+    if (body !== undefined) {
+      headers['Content-Type'] = 'application/json';
+    }
+    return fetchFn(url, {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
   };
 
-  if (body !== undefined) {
-    headers['Content-Type'] = 'application/json';
-  }
+  let response = await doFetch(await getValidAccessToken(deps));
 
-  const response = await fetchFn(url, {
-    method,
-    headers,
-    body: body !== undefined ? JSON.stringify(body) : undefined,
-  });
+  // Proactive refresh (getValidAccessToken) only covers clock-based expiry. A 401
+  // still lands when a token is revoked, invalidated early, or its stored expiry
+  // is wrong — force one refresh and retry before surfacing the failure, so an
+  // agent mid-run doesn't hard-fail on a token that could have been renewed.
+  if (response.status === 401) {
+    const refreshed = await forceRefresh(config, deps).catch(() => null);
+    if (refreshed) response = await doFetch(refreshed);
+  }
 
   if (!response.ok) {
     const error = await response.text();
+    if (response.status === 401) {
+      throw new Error(`API request failed (401): ${error}\nToken refresh did not resolve it — run: ats auth login`);
+    }
     throw new Error(`API request failed (${response.status}): ${error}`);
   }
 

--- a/packages/adapter-ticktick/test/auth-retry.test.js
+++ b/packages/adapter-ticktick/test/auth-retry.test.js
@@ -1,0 +1,67 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { apiRequest } from '../api.js';
+
+// A token whose clock-based expiry is still in the future, so getValidAccessToken's
+// PROACTIVE refresh is skipped — isolating the reactive 401 path we added.
+const validTokens = { accessToken: 'old', refreshToken: 'r', expiresAt: Date.now() + 3_600_000 };
+
+function depsWith(fetchFn, tokens = validTokens) {
+  return {
+    existsSync: () => true,
+    readFile: async () => JSON.stringify(tokens),
+    writeFile: async () => {},
+    fetchFn,
+  };
+}
+
+function withEnv(fn) {
+  // loadConfig prefers env, so we don't touch any config file.
+  process.env.TICKTICK_CLIENT_ID = 'cid';
+  process.env.TICKTICK_CLIENT_SECRET = 'secret';
+  return Promise.resolve()
+    .then(fn)
+    .finally(() => {
+      delete process.env.TICKTICK_CLIENT_ID;
+      delete process.env.TICKTICK_CLIENT_SECRET;
+    });
+}
+
+test('apiRequest refreshes and retries once on a 401, then succeeds', () => withEnv(async () => {
+  let refreshed = false;
+  const fetchFn = async (url, opts) => {
+    if (url.includes('/oauth/token')) {
+      refreshed = true;
+      return { ok: true, json: async () => ({ access_token: 'new', refresh_token: 'r', expires_in: 3600, token_type: 'Bearer' }) };
+    }
+    // API call: the stale token 401s; the refreshed token succeeds.
+    if (opts.headers.Authorization === 'Bearer old') return { ok: false, status: 401, text: async () => 'token revoked' };
+    return { ok: true, status: 200, text: async () => JSON.stringify({ id: 't1' }) };
+  };
+  const res = await apiRequest('GET', '/task/t1', undefined, depsWith(fetchFn));
+  assert.deepEqual(res, { id: 't1' });
+  assert.equal(refreshed, true); // it actually refreshed rather than throwing
+}));
+
+test('apiRequest surfaces an actionable error when the refresh cannot fix the 401', () => withEnv(async () => {
+  const fetchFn = async (url) => {
+    if (url.includes('/oauth/token')) return { ok: false, status: 400, text: async () => 'invalid_grant' };
+    return { ok: false, status: 401, text: async () => 'unauthorized' };
+  };
+  await assert.rejects(
+    () => apiRequest('GET', '/task/t1', undefined, depsWith(fetchFn)),
+    /run: ats auth login/,
+  );
+}));
+
+test('apiRequest does not refresh when the first call succeeds', () => withEnv(async () => {
+  let refreshCalls = 0;
+  const fetchFn = async (url) => {
+    if (url.includes('/oauth/token')) { refreshCalls++; return { ok: true, json: async () => ({}) }; }
+    return { ok: true, status: 200, text: async () => JSON.stringify({ id: 't1' }) };
+  };
+  const res = await apiRequest('GET', '/task/t1', undefined, depsWith(fetchFn));
+  assert.deepEqual(res, { id: 't1' });
+  assert.equal(refreshCalls, 0); // healthy path untouched — no extra refresh
+}));

--- a/packages/cli/bin/ats.js
+++ b/packages/cli/bin/ats.js
@@ -38,6 +38,9 @@ import {
   formatConformance,
   find as coreFind,
   similar as coreSimilar,
+  loadCorpus as coreLoadCorpus,
+  detectDuplicates,
+  formatDedup,
   logUsage,
   parseTaskMetadata,
   taskMetadataForRead,
@@ -211,6 +214,16 @@ async function main() {
       case 'bench':
         handleBench();
         return;
+      case 'usage':
+        // `ats usage [--json] [--days=N] [--since=D]` — retrieval observability
+        // (per-tool volume, empty/error/degraded rates, latency, re-queries).
+        // Aliases the analyze-usage renderer, which reads the same usage log.
+        args.subcommand = 'analyze-usage';
+        handleBench();
+        return;
+      case 'dedup':
+        await handleDedup();
+        return;
       case 'fmt':
         handleFmt();
         return;
@@ -375,9 +388,9 @@ function helpFor(command) {
 }
 
 const COMPLETION_COMMANDS = [
-  'setup', 'find', 'open', 'get', 'url', 'links', 'create', 'update', 'hybrid', 'similar',
+  'setup', 'find', 'dedup', 'open', 'get', 'url', 'links', 'create', 'update', 'hybrid', 'similar',
   'intent', 'promote', 'hierarchy', 'lifecycle', 'link', 'reference', 'relate', 'graph', 'context', 'ledger', 'security', 'events',
-  'doctor', 'status', 'cache', 'bench', 'fmt', 'sync', 'adapter', 'init', 'config', 'auth',
+  'doctor', 'status', 'cache', 'bench', 'usage', 'fmt', 'sync', 'adapter', 'init', 'config', 'auth',
   'projects', 'tasks', 'notes', 'help', 'completion', 'undo',
 ];
 
@@ -542,6 +555,24 @@ function handleBench() {
   });
   if (result.error) throw result.error;
   if (result.status !== 0) process.exit(result.status || 1);
+}
+
+// `ats dedup [--threshold 0.6] [--max-corpus N] [--no-cache] [--json]` — scan the
+// corpus for near-duplicate (and disagreeing) tasks so an agent can link/merge
+// them instead of recalling contradictory copies. Detection only; it never edits.
+async function handleDedup() {
+  const adapter = await loadAdapter();
+  const { corpus } = await coreLoadCorpus(adapter, { cache: !args.options['no-cache'] });
+  const threshold = args.options.threshold !== undefined ? parseFloat(args.options.threshold) : 0.6;
+  const report = detectDuplicates(corpus, {
+    threshold: Number.isFinite(threshold) ? threshold : 0.6,
+    maxCorpus: parseInt(args.options['max-corpus']) || undefined,
+  });
+  if (args.options.format === 'json') {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(formatDedup(report));
+  }
 }
 
 async function handleSync() {
@@ -887,7 +918,13 @@ async function handleTasks() {
     }
     case 'find': {
       if (!args.positional[0]) { console.error('Usage: ats tasks find QUERY'); process.exit(1); }
-      const opts = { limit, budgetMs: parseInt(args.options['budget-ms']) || 3000, explain: !!args.options.explain };
+      const opts = {
+        limit,
+        budgetMs: parseInt(args.options['budget-ms']) || 3000,
+        explain: !!args.options.explain,
+        rerank: !!args.options.rerank,
+        rerankDepth: parseInt(args.options['rerank-depth']) || undefined,
+      };
       // Rich adapters bring their own embedder-backed find; generic adapters get
       // core's storage-agnostic keyword + native + RRF fan-out over the contract.
       return t?.find ? await t.find(args.positional[0], opts) : await coreFind(args.positional[0], { adapter, ...opts, log: logUsage });

--- a/packages/core/bench/analyze-usage.js
+++ b/packages/core/bench/analyze-usage.js
@@ -1,40 +1,41 @@
 #!/usr/bin/env node
 /**
- * bench/analyze-usage.js — read ~/.config/ats/search-log.jsonl and
- * report which tools got called, how often, with what results, and surface
- * "re-query within 60s" pairs as a proxy for "first result was bad."
+ * bench/analyze-usage.js — read ~/.config/ats/search-log.jsonl and report which
+ * tools got called, how often, with what results + latency, and surface
+ * "re-query within 60s" pairs as a proxy for "the first result was bad."
+ *
+ * Rendering only — the analysis lives in core `usage-log.summarize()` so `ats
+ * usage` (JSON) and this script (markdown) agree by construction.
  *
  * Usage:
- *   node bench/analyze-usage.js                # all time
+ *   node bench/analyze-usage.js                # all time, markdown
  *   node bench/analyze-usage.js --days=14      # last N days
  *   node bench/analyze-usage.js --since=2026-04-15
+ *   node bench/analyze-usage.js --json         # machine-readable stats object
  */
 
 import fs from 'fs';
-import path from 'path';
-import os from 'os';
-
-const LOG_PATH = process.env.ATS_USAGE_LOG ||
-  path.join(os.homedir(), '.config', 'ats', 'search-log.jsonl');
+import { readEntries, summarize, logPath } from '../usage-log.js';
 
 const args = parseArgs(process.argv.slice(2));
 const cutoff = computeCutoff(args);
+const LOG_PATH = logPath();
+
+const entries = readEntries({ since: cutoff });
+const stats = summarize(entries);
+
+// `--json` directly, or `--format=json` as forwarded by the `ats usage` alias
+// (ATS maps its global `--json` shorthand to `--format json`).
+if (args.json || args.format === 'json') {
+  console.log(JSON.stringify({ window: cutoff ? cutoff.toISOString() : null, ...stats }, null, 2));
+  process.exit(0);
+}
 
 if (!fs.existsSync(LOG_PATH)) {
   console.log(`No usage log yet at ${LOG_PATH}.`);
   console.log('Once you (or scripts) run a few searches, re-run this.');
   process.exit(0);
 }
-
-const entries = fs.readFileSync(LOG_PATH, 'utf8')
-  .split('\n')
-  .filter((l) => l.trim())
-  .map((l) => {
-    try { return JSON.parse(l); } catch { return null; }
-  })
-  .filter(Boolean)
-  .filter((e) => !cutoff || new Date(e.ts) >= cutoff);
-
 if (entries.length === 0) {
   console.log(`No entries in window. Log: ${LOG_PATH}`);
   process.exit(0);
@@ -42,73 +43,40 @@ if (entries.length === 0) {
 
 const window = cutoff ? `since ${cutoff.toISOString().slice(0, 10)}` : 'all time';
 console.log(`# Search Usage Report (${window})\n`);
-console.log(`Total calls: ${entries.length}`);
+console.log(`Total calls: ${stats.totalCalls}`);
 console.log(`Source: ${LOG_PATH}\n`);
 
 // --- Per-tool stats -------------------------------------------------------
-const byTool = {};
-for (const e of entries) {
-  const t = e.tool;
-  if (!byTool[t]) byTool[t] = { calls: 0, empty: 0, errors: 0, totalResults: 0, queryLens: [] };
-  byTool[t].calls++;
-  if (e.error) byTool[t].errors++;
-  if (!e.error && (e.resultCount || 0) === 0) byTool[t].empty++;
-  byTool[t].totalResults += e.resultCount || 0;
-  byTool[t].queryLens.push(e.queryLen || 0);
-}
-
 console.log('## Calls per tool\n');
-console.log('| Tool | Calls | Empty rate | Error rate | Avg results | Median query len |');
-console.log('| ---- | ----- | ---------- | ---------- | ----------- | ---------------- |');
-const sortedTools = Object.entries(byTool).sort((a, b) => b[1].calls - a[1].calls);
-for (const [tool, s] of sortedTools) {
-  const emptyRate = ((s.empty / s.calls) * 100).toFixed(0) + '%';
-  const errorRate = ((s.errors / s.calls) * 100).toFixed(0) + '%';
-  const avgRes = (s.totalResults / s.calls).toFixed(1);
-  const medQ = median(s.queryLens);
-  console.log(`| ${tool} | ${s.calls} | ${emptyRate} | ${errorRate} | ${avgRes} | ${medQ} chars |`);
+console.log('| Tool | Calls | Empty | Error | Degraded | Avg results | Median q-len | Avg ms | p95 ms |');
+console.log('| ---- | ----- | ----- | ----- | -------- | ----------- | ------------ | ------ | ------ |');
+for (const s of stats.perTool) {
+  console.log(
+    `| ${s.tool} | ${s.calls} | ${pct(s.emptyRate)} | ${pct(s.errorRate)} | ${pct(s.degradedRate)} | ` +
+    `${s.avgResults} | ${s.medianQueryLen} chars | ${s.avgMs ?? '—'} | ${s.p95Ms ?? '—'} |`
+  );
 }
 
 // --- Re-query within 60s (signals "first result was bad") -----------------
 console.log('\n## Re-queries within 60s\n');
 console.log('Pairs where the same caller (same pid) issued a new search within 60s of a previous one. Heuristic for "first result was unsatisfactory."\n');
-const sorted = [...entries].sort((a, b) => new Date(a.ts) - new Date(b.ts));
-const pairs = [];
-const lastByPid = new Map();
-for (const e of sorted) {
-  const last = lastByPid.get(e.pid);
-  if (last) {
-    const dtMs = new Date(e.ts) - new Date(last.ts);
-    if (dtMs <= 60_000) {
-      pairs.push({ first: last, second: e, dtMs });
-    }
-  }
-  lastByPid.set(e.pid, e);
-}
-if (pairs.length === 0) {
+if (stats.reQueries.length === 0) {
   console.log('(none)');
 } else {
-  console.log(`Total: ${pairs.length} re-query pairs.\n`);
-  for (const p of pairs.slice(0, 15)) {
-    console.log(`- ${p.first.tool}("${truncate(p.first.query, 40)}") → ${p.second.tool}("${truncate(p.second.query, 40)}") (+${(p.dtMs / 1000).toFixed(1)}s)`);
+  console.log(`Total: ${stats.reQueries.length} re-query pairs.\n`);
+  for (const p of stats.reQueries.slice(0, 15)) {
+    console.log(`- ${p.from.tool}("${truncate(p.from.query, 40)}") → ${p.to.tool}("${truncate(p.to.query, 40)}") (+${(p.dtMs / 1000).toFixed(1)}s)`);
   }
-  if (pairs.length > 15) console.log(`  …and ${pairs.length - 15} more`);
+  if (stats.reQueries.length > 15) console.log(`  …and ${stats.reQueries.length - 15} more`);
 }
 
 // --- Top queries (frequency) ----------------------------------------------
 console.log('\n## Top queries (frequency, any tool)\n');
-const qFreq = {};
-for (const e of entries) {
-  const k = `${e.tool}|${(e.query || '').toLowerCase()}`;
-  qFreq[k] = (qFreq[k] || 0) + 1;
-}
-const top = Object.entries(qFreq).sort((a, b) => b[1] - a[1]).slice(0, 10);
-if (top.length === 0) {
+if (stats.topQueries.length === 0) {
   console.log('(none)');
 } else {
-  for (const [k, n] of top) {
-    const [tool, q] = k.split('|');
-    console.log(`- ${n}× ${tool}: "${q}"`);
+  for (const q of stats.topQueries) {
+    console.log(`- ${q.count}× ${q.tool}: "${q.query}"`);
   }
 }
 
@@ -123,21 +91,18 @@ function parseArgs(argv) {
   return out;
 }
 
-function computeCutoff(args) {
-  if (args.since) return new Date(args.since);
-  if (args.days) {
+function computeCutoff(a) {
+  if (a.since) return new Date(a.since);
+  if (a.days) {
     const d = new Date();
-    d.setDate(d.getDate() - Number(args.days));
+    d.setDate(d.getDate() - Number(a.days));
     return d;
   }
   return null;
 }
 
-function median(arr) {
-  if (arr.length === 0) return 0;
-  const sorted = [...arr].sort((a, b) => a - b);
-  const m = Math.floor(sorted.length / 2);
-  return sorted.length % 2 ? sorted[m] : Math.round((sorted[m - 1] + sorted[m]) / 2);
+function pct(rate) {
+  return `${Math.round((rate || 0) * 100)}%`;
 }
 
 function truncate(s, n) {

--- a/packages/core/dedup.js
+++ b/packages/core/dedup.js
@@ -1,0 +1,127 @@
+/**
+ * Corpus-level near-duplicate + contradiction detection.
+ *
+ * ATS already lets you ASSERT that two tasks conflict or supersede one another
+ * (the `conflicts-with` / `supersedes` link types) — but only by hand. This
+ * finds the candidates for you: clusters of tasks that look like the same thing
+ * captured more than once (often the same fact re-entered across adapters), so
+ * an agent can link or merge them instead of later recalling contradictory
+ * copies of the same memory.
+ *
+ * Dependency-free and deterministic: lexical token-set (Jaccard) similarity over
+ * title + content + tags. O(n^2) over the corpus — fine for the
+ * thousands-of-tasks corpora ATS targets; `maxCorpus` caps the scan and sets a
+ * `truncated` flag rather than silently dropping the tail.
+ */
+
+// Common words carry no dedup signal; dropping them keeps "Deploy the app" and
+// "Deploy app" from scoring lower than they should.
+const STOP = new Set(['the', 'a', 'an', 'to', 'of', 'and', 'or', 'for', 'in', 'on', 'with', 'is', 'it', 'this', 'that', 'at', 'by', 'be']);
+
+function tokenSet(task) {
+  const text = [task.title, task.content, ...(task.tags || [])].filter(Boolean).join(' ').toLowerCase();
+  return new Set((text.match(/[a-z0-9]+/g) || []).filter((t) => t.length > 1 && !STOP.has(t)));
+}
+
+function jaccard(a, b) {
+  if (a.size === 0 || b.size === 0) return 0;
+  const [small, large] = a.size <= b.size ? [a, b] : [b, a];
+  let inter = 0;
+  for (const t of small) if (large.has(t)) inter++;
+  return inter / (a.size + b.size - inter);
+}
+
+function taskKey(t) {
+  return t.fullId || t.id;
+}
+
+/**
+ * Detect near-duplicate clusters and, within each, field-level disagreements
+ * (a proxy for contradiction — the "same" task with a different status/due/etc).
+ *
+ * @param {Array<object>} corpus
+ * @param {{threshold?:number, maxCorpus?:number, conflictFields?:string[]}} [opts]
+ * @returns {{scanned:number, truncated:boolean, clusters:Array<{
+ *   size:number, similarity:number,
+ *   members:Array<{id:string,title:string,projectName?:string,projectId?:string}>,
+ *   conflicts:Array<{field:string,values:Array}>}>}}
+ */
+export function detectDuplicates(corpus, { threshold = 0.6, maxCorpus = 2000, conflictFields = ['status', 'priority', 'dueDate'] } = {}) {
+  const items = (corpus || []).filter((t) => taskKey(t));
+  const truncated = items.length > maxCorpus;
+  const scan = truncated ? items.slice(0, maxCorpus) : items;
+  const sets = scan.map(tokenSet);
+
+  // Union-find: every above-threshold pair unions two tasks; connected
+  // components become clusters (so A~B and B~C group A, B, C together).
+  const parent = scan.map((_, i) => i);
+  const root = (i) => {
+    while (parent[i] !== i) { parent[i] = parent[parent[i]]; i = parent[i]; }
+    return i;
+  };
+  const union = (i, j) => {
+    const ri = root(i);
+    const rj = root(j);
+    if (ri !== rj) parent[ri] = rj;
+  };
+  for (let i = 0; i < scan.length; i++) {
+    for (let j = i + 1; j < scan.length; j++) {
+      if (jaccard(sets[i], sets[j]) >= threshold) union(i, j);
+    }
+  }
+
+  const groups = new Map();
+  for (let i = 0; i < scan.length; i++) {
+    const r = root(i);
+    if (!groups.has(r)) groups.set(r, []);
+    groups.get(r).push(i);
+  }
+
+  const clusters = [];
+  for (const idxs of groups.values()) {
+    if (idxs.length < 2) continue;
+    let maxSim = 0;
+    for (let a = 0; a < idxs.length; a++) {
+      for (let b = a + 1; b < idxs.length; b++) {
+        maxSim = Math.max(maxSim, jaccard(sets[idxs[a]], sets[idxs[b]]));
+      }
+    }
+    const members = idxs.map((i) => ({
+      id: taskKey(scan[i]),
+      title: scan[i].title,
+      projectName: scan[i].projectName,
+      projectId: scan[i].projectId ?? scan[i].fullProjectId,
+    }));
+    const conflicts = [];
+    for (const f of conflictFields) {
+      const values = [...new Set(idxs.map((i) => scan[i][f]).filter((v) => v !== undefined && v !== null && v !== ''))];
+      if (values.length > 1) conflicts.push({ field: f, values });
+    }
+    clusters.push({ size: idxs.length, similarity: Math.round(maxSim * 100) / 100, members, conflicts });
+  }
+  clusters.sort((a, b) => b.similarity - a.similarity || b.size - a.size);
+  return { scanned: scan.length, truncated, clusters };
+}
+
+/** Render a dedup report as a compact, human-readable string. */
+export function formatDedup(report) {
+  const lines = [`# Duplicate / contradiction scan (${report.scanned} tasks scanned${report.truncated ? ', truncated at maxCorpus' : ''})`];
+  if (report.clusters.length === 0) {
+    lines.push('', 'No likely-duplicate clusters found.');
+    return lines.join('\n');
+  }
+  lines.push('', `${report.clusters.length} likely-duplicate cluster(s):`, '');
+  for (const c of report.clusters) {
+    const flag = c.conflicts.length ? `  ⚠ conflicting: ${c.conflicts.map((x) => x.field).join(', ')}` : '';
+    lines.push(`• ${c.size} tasks · similarity ${c.similarity}${flag}`);
+    for (const m of c.members) {
+      lines.push(`    - [${m.projectName || m.projectId || '?'}] ${m.title}  (${m.id})`);
+    }
+    for (const x of c.conflicts) {
+      lines.push(`    ⚠ ${x.field}: ${x.values.join(' vs ')}`);
+    }
+    lines.push('');
+  }
+  lines.push('Act on these with a typed link, e.g. `ats link add <A> <B> --type supersedes` (or conflicts-with).');
+  return lines.join('\n');
+}

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -1,5 +1,6 @@
 export { validateAdapter, adapterCapabilities } from './adapter-interface.js';
 export { rrf, fuse, find, loadCorpus, similar, RRF_K } from './retrieval.js';
+export { detectDuplicates, formatDedup } from './dedup.js';
 export {
   read as readCorpus,
   write as writeCorpus,

--- a/packages/core/retrieval.js
+++ b/packages/core/retrieval.js
@@ -109,13 +109,22 @@ export async function loadCorpus(adapter, { cache = true } = {}) {
     const cached = corpusCache.read();
     if (cached) {
       const m = corpusCache.meta();
-      return { corpus: cached, fromCache: true, ageMs: m.ageMs ?? null };
+      return { corpus: cached, fromCache: true, ageMs: m.ageMs ?? null, sourcesFailed: [] };
     }
   }
 
   let corpus;
+  const sourcesFailed = [];
   if (typeof adapter.bulkFetch === 'function') {
     corpus = await adapter.bulkFetch();
+    // A multi-source adapter (composite) records any child backend it silently
+    // dropped during the fan-out. Surface them so a partial corpus is not
+    // mistaken for a complete one.
+    if (Array.isArray(adapter.__fetchWarnings)) {
+      for (const w of adapter.__fetchWarnings) {
+        sourcesFailed.push({ source: w.source, name: w.source, error: w.error });
+      }
+    }
   } else {
     const projects = await adapter.listProjects();
     corpus = [];
@@ -125,13 +134,18 @@ export async function loadCorpus(adapter, { cache = true } = {}) {
         for (const t of tasks) {
           corpus.push({ projectName: p.name, ...t });
         }
-      } catch {
-        // skip projects that fail individually
+      } catch (err) {
+        // A single project failing must not silently shrink the corpus with no
+        // trace: record it so `find` can report the result is partial.
+        sourcesFailed.push({ source: p.id, name: p.name, error: err.message });
       }
     }
   }
-  if (cache) corpusCache.write(corpus);
-  return { corpus, fromCache: false, ageMs: null };
+  // Never persist a known-partial corpus: caching it would serve an incomplete
+  // result as complete (and healthy) for the whole TTL. Retry the failed sources
+  // on the next call instead.
+  if (cache && sourcesFailed.length === 0) corpusCache.write(corpus);
+  return { corpus, fromCache: false, ageMs: null, sourcesFailed };
 }
 
 /** Built-in substring keyword retriever. Pure CPU over the corpus. */
@@ -254,6 +268,42 @@ function withDeadline(run, ms) {
 }
 
 /**
+ * Built-in, dependency-free reranker (a "cross-encoder-lite").
+ *
+ * RRF fuses by rank POSITION across branches, so it never reads how well a
+ * candidate actually matches the query. This re-scores the fused pool directly
+ * against the query text — query-term coverage with a title>body field weight,
+ * plus an exact-phrase bonus — and breaks ties by the original fused score so it
+ * is fully deterministic. Callers can pass their own async reranker (e.g. a
+ * cross-encoder or LLM) instead; this is the zero-config default.
+ *
+ * @param {string} query
+ * @param {Array<object>} candidates - fused docs (carry `rrf`)
+ * @returns {Array<object>} candidates reordered, best first
+ */
+export function builtinRerank(query, candidates) {
+  const qTokens = [...new Set(String(query || '').toLowerCase().match(/[a-z0-9]+/g) || [])];
+  if (qTokens.length === 0) return candidates;
+  const qPhrase = String(query || '').toLowerCase().trim();
+  return candidates
+    .map((doc, i) => {
+      const title = (doc.title || '').toLowerCase();
+      const content = (doc.content || '').toLowerCase();
+      let score = 0;
+      for (const tok of qTokens) {
+        if (title.includes(tok)) score += 3;
+        else if (content.includes(tok)) score += 1;
+      }
+      score /= qTokens.length; // coverage-normalized
+      if (qPhrase && title.includes(qPhrase)) score += 2;
+      else if (qPhrase && content.includes(qPhrase)) score += 1;
+      return { doc, score, i, rrf: doc.rrf ?? 0 };
+    })
+    .sort((a, b) => b.score - a.score || b.rrf - a.rrf || a.i - b.i)
+    .map((entry) => entry.doc);
+}
+
+/**
  * Parallel fan-out retrieval fused with RRF.
  *
  * Branches (each returns a ranked list of docs, all races a shared budget):
@@ -276,9 +326,14 @@ function withDeadline(run, ms) {
  * @param {boolean} [cfg.includeKeyword=true] - include Core's keyword branch
  * @param {boolean} [cfg.includeNative=true] - include adapter.searchByQuery
  * @param {boolean} [cfg.explain=false] - attach per-result rank/contribution breakdown
+ * @param {boolean|Function} [cfg.rerank=false] - second-stage reranker over the fused
+ *   pool. `true` uses the built-in lexical scorer; a function (query, docs) => docs
+ *   plugs a custom reranker (cross-encoder/LLM). Off by default (pure RRF).
+ * @param {number} [cfg.rerankDepth] - how many fused candidates to feed the reranker
+ *   before trimming to `limit` (default max(limit*4, candidatesPerSource))
  * @param {Function} [cfg.loadCorpus] - override the corpus loader (store-specific)
  * @param {Function} [cfg.log] - usage-log record callback
- * @returns {Promise<object>} { query, mode, count, elapsedMs, corpus, branches, tasks }
+ * @returns {Promise<object>} { query, mode, count, degraded, elapsedMs, corpus, branches, tasks }
  */
 export async function find(query, cfg = {}) {
   const {
@@ -293,6 +348,8 @@ export async function find(query, cfg = {}) {
     includeKeyword = true,
     includeNative = true,
     explain = false,
+    rerank = false,
+    rerankDepth,
     loadCorpus: loadCorpusOverride,
     log,
   } = cfg;
@@ -318,6 +375,8 @@ export async function find(query, cfg = {}) {
       query,
       mode: 'find-failed',
       error: `corpus load failed: ${err.message}`,
+      degraded: true,
+      warnings: [`corpus load failed: ${err.message}`],
       count: 0,
       elapsedMs: Date.now() - t0,
       branches: [],
@@ -325,6 +384,7 @@ export async function find(query, cfg = {}) {
     };
   }
   const { corpus, fromCache, ageMs } = corpusInfo;
+  const sourcesFailed = corpusInfo.sourcesFailed || [];
 
   // Assemble branches. Branches are pure CPU over the shared corpus (plus the
   // optional hybrid call), so we can always run them all in parallel.
@@ -394,7 +454,26 @@ export async function find(query, cfg = {}) {
   );
 
   const branches = settled.filter((b) => b.ok).map((b) => ({ name: b.name, docs: b.value }));
-  const tasks = fuse(branches, { k, limit, explain });
+
+  // Reranking (optional). RRF ranks by fused position, not match quality; when a
+  // reranker is requested, fuse a wider `rerankDepth` pool, re-score it, then trim
+  // to `limit`. A failing reranker never sinks the query — it falls back to the
+  // fused order and is recorded as a degraded source (surfaced below).
+  const depth = rerankDepth || Math.max(limit * 4, candidatesPerSource);
+  let tasks = fuse(branches, { k, limit: rerank ? depth : limit, explain });
+  let reranked = false;
+  if (rerank) {
+    const reranker = typeof rerank === 'function' ? rerank : builtinRerank;
+    const rerankStart = Date.now();
+    try {
+      const out = await reranker(query, tasks);
+      tasks = (Array.isArray(out) ? out : tasks).slice(0, limit);
+      reranked = Array.isArray(out);
+    } catch (err) {
+      tasks = tasks.slice(0, limit);
+      settled.push({ name: 'rerank', ok: false, value: [], error: err.message, elapsedMs: Date.now() - rerankStart });
+    }
+  }
 
   const branchSummary = settled.map((b) => ({
     name: b.name,
@@ -404,13 +483,23 @@ export async function find(query, cfg = {}) {
     error: b.error || undefined,
   }));
 
+  // Roll partial failures up into one signal the caller can branch on without
+  // hand-walking `branches`: a dropped corpus source, or a retrieval branch that
+  // errored/timed out, means the result set is incomplete — say so.
+  const warnings = [
+    ...sourcesFailed.map((s) => `source "${s.name || s.source}" failed to load: ${s.error}`),
+    ...settled.filter((b) => !b.ok).map((b) => `retrieval branch "${b.name}" failed: ${b.error}`),
+  ];
+  const degraded = warnings.length > 0;
+
   if (typeof log === 'function') {
     log({
       tool: 'find',
       query,
       resultCount: tasks.length,
       topId: tasks[0]?.id || null,
-      meta: { budgetMs, branches: branchSummary },
+      durationMs: Date.now() - t0,
+      meta: { budgetMs, degraded, branches: branchSummary },
     });
   }
 
@@ -418,9 +507,12 @@ export async function find(query, cfg = {}) {
     query,
     mode: 'find',
     count: tasks.length,
+    degraded,
+    ...(rerank ? { reranked } : {}),
     elapsedMs: Date.now() - t0,
-    corpus: { fromCache, ageMs, size: corpus.length },
+    corpus: { fromCache, ageMs, size: corpus.length, sourcesFailed },
     branches: branchSummary,
+    ...(warnings.length ? { warnings } : {}),
     ...(explain ? { k } : {}),
     tasks,
   };
@@ -435,6 +527,7 @@ export async function find(query, cfg = {}) {
  */
 export async function similar(taskId, cfg = {}) {
   const { embedder, adapter, limit = 5, cache = true, log } = cfg;
+  const t0 = Date.now();
   try {
     let result;
     if (embedder && typeof embedder.findSimilar === 'function') {
@@ -468,12 +561,13 @@ export async function similar(taskId, cfg = {}) {
         query: taskId,
         resultCount: Array.isArray(result?.similar) ? result.similar.length : 0,
         topId: result?.similar?.[0]?.id || null,
+        durationMs: Date.now() - t0,
       });
     }
     return result;
   } catch (err) {
     if (typeof log === 'function') {
-      log({ tool: 'similar', query: taskId, resultCount: 0, topId: null, error: err.message });
+      log({ tool: 'similar', query: taskId, resultCount: 0, topId: null, durationMs: Date.now() - t0, error: err.message });
     }
     throw err;
   }

--- a/packages/core/test/dedup.test.js
+++ b/packages/core/test/dedup.test.js
@@ -1,0 +1,64 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { detectDuplicates, formatDedup } from '../dedup.js';
+
+test('detectDuplicates clusters near-identical tasks and leaves unique ones alone', () => {
+  const corpus = [
+    { id: 'a', title: 'Deploy the billing service to production', content: 'run the deploy script', projectId: 'p1' },
+    { id: 'b', title: 'Deploy billing service to production', content: 'run deploy script', projectId: 'p2' },
+    { id: 'c', title: 'Buy oat milk and bananas', content: 'grocery run', projectId: 'p1' },
+  ];
+  const { clusters, scanned } = detectDuplicates(corpus, { threshold: 0.5 });
+  assert.equal(scanned, 3);
+  assert.equal(clusters.length, 1);
+  assert.equal(clusters[0].size, 2);
+  assert.deepEqual(clusters[0].members.map((m) => m.id).sort(), ['a', 'b']);
+  assert.ok(clusters[0].similarity >= 0.5);
+});
+
+test('detectDuplicates flags field-level disagreement as a potential contradiction', () => {
+  const corpus = [
+    { id: 'x', title: 'Renew the SSL certificate for api.example.com', content: 'cert renewal', status: 'active', projectId: 'p' },
+    { id: 'y', title: 'Renew SSL certificate for api.example.com', content: 'cert renewal', status: 'completed', projectId: 'p' },
+  ];
+  const { clusters } = detectDuplicates(corpus, { threshold: 0.5 });
+  assert.equal(clusters.length, 1);
+  const statusConflict = clusters[0].conflicts.find((c) => c.field === 'status');
+  assert.ok(statusConflict);
+  assert.deepEqual(statusConflict.values.sort(), ['active', 'completed']);
+});
+
+test('detectDuplicates transitively groups A~B~C into one cluster', () => {
+  const corpus = [
+    { id: 'a', title: 'kubernetes deployment guide staging', content: '', projectId: 'p' },
+    { id: 'b', title: 'kubernetes deployment guide staging cluster', content: '', projectId: 'p' },
+    { id: 'c', title: 'kubernetes deployment guide staging notes', content: '', projectId: 'p' },
+  ];
+  const { clusters } = detectDuplicates(corpus, { threshold: 0.5 });
+  assert.equal(clusters.length, 1);
+  assert.equal(clusters[0].size, 3);
+});
+
+test('detectDuplicates caps the scan at maxCorpus and flags truncation', () => {
+  const corpus = Array.from({ length: 5 }, (_, i) => ({ id: `t${i}`, title: `unrelated topic ${i}`, content: '', projectId: 'p' }));
+  const { truncated, scanned } = detectDuplicates(corpus, { maxCorpus: 3 });
+  assert.equal(truncated, true);
+  assert.equal(scanned, 3);
+});
+
+test('formatDedup renders clusters, conflicts, and a no-op message', () => {
+  assert.match(formatDedup({ scanned: 0, truncated: false, clusters: [] }), /No likely-duplicate clusters/);
+  const out = formatDedup({
+    scanned: 2,
+    truncated: false,
+    clusters: [{
+      size: 2,
+      similarity: 0.9,
+      members: [{ id: 'a', title: 'X', projectName: 'P' }, { id: 'b', title: 'Y', projectName: 'P' }],
+      conflicts: [{ field: 'status', values: ['active', 'completed'] }],
+    }],
+  });
+  assert.match(out, /similarity 0\.9/);
+  assert.match(out, /status: active vs completed/);
+});

--- a/packages/core/test/retrieval.test.js
+++ b/packages/core/test/retrieval.test.js
@@ -4,7 +4,7 @@ import { strict as assert } from 'node:assert';
 // Keep the on-disk corpus cache out of the picture for deterministic tests.
 process.env.ATS_CORPUS_CACHE_DISABLE = '1';
 
-import { rrf, fuse, find, loadCorpus, similar } from '../retrieval.js';
+import { rrf, fuse, find, loadCorpus, similar, builtinRerank } from '../retrieval.js';
 
 const NOW = new Date().toISOString();
 
@@ -241,4 +241,79 @@ test('similar rejects malformed adapter embedding output', async () => {
     () => similar('t1', { adapter, cache: false }),
     /returned 1 vectors for 2 texts/
   );
+});
+
+test('find flags degraded + warns when a retrieval branch fails', async () => {
+  const flakyBranch = { name: 'flaky', run: async () => { throw new Error('backend 503'); } };
+  const res = await find('ffmpeg', { adapter: fakeAdapter, cache: false, retrievers: [flakyBranch] });
+  assert.equal(res.degraded, true);
+  assert.ok(res.warnings.some((w) => w.includes('flaky') && w.includes('503')));
+  // The keyword branch still succeeded, so results are still returned — degraded, not empty.
+  assert.ok(res.tasks.length > 0);
+  assert.ok(res.branches.some((b) => b.name === 'flaky' && !b.ok));
+});
+
+test('find flags degraded + warns when a corpus source fails to load', async () => {
+  const flaky = {
+    listProjects: async () => [{ id: 'p1', name: 'Good' }, { id: 'p2', name: 'Broken' }],
+    listTasksInProject: async (pid) => {
+      if (pid === 'p2') throw new Error('project fetch 500');
+      return [{ id: 't1', title: 'ffmpeg render', content: '', projectId: 'p1', tags: [] }];
+    },
+  };
+  const res = await find('ffmpeg', { adapter: flaky, cache: false });
+  assert.equal(res.degraded, true);
+  assert.ok(res.warnings.some((w) => w.includes('Broken') && w.includes('500')));
+  assert.deepEqual(res.corpus.sourcesFailed.map((s) => s.name), ['Broken']);
+  // The healthy project's task is still returned.
+  assert.equal(res.tasks[0].id, 't1');
+});
+
+test('find is not degraded and omits warnings on a healthy run', async () => {
+  const res = await find('ffmpeg', { adapter: fakeAdapter, cache: false });
+  assert.equal(res.degraded, false);
+  assert.equal(res.warnings, undefined);
+  assert.deepEqual(res.corpus.sourcesFailed, []);
+  assert.equal(res.reranked, undefined); // rerank off by default
+});
+
+test('builtinRerank scores stronger textual matches over a higher-RRF weak match', () => {
+  const docs = [
+    { id: 'weak', title: 'z', content: 'mentions kube once', rrf: 0.9 },
+    { id: 'strong', title: 'kube deployment guide', content: 'kube kube', rrf: 0.1 },
+  ];
+  const out = builtinRerank('kube', docs);
+  assert.equal(out[0].id, 'strong'); // beats the higher-rrf but weaker-text doc
+});
+
+test('rerank feeds the reranker a pool wider than the final limit, then trims', async () => {
+  const corpus = Array.from({ length: 8 }, (_, i) => ({ id: `d${i}`, title: `deploy note ${i}`, content: '', projectId: 'p', tags: [] }));
+  let sawCandidates = 0;
+  const rerank = async (_q, docs) => { sawCandidates = docs.length; return docs; };
+  const res = await find('deploy', {
+    loadCorpus: async () => ({ corpus, fromCache: false, ageMs: null }),
+    limit: 3, includeNative: false, rerank, rerankDepth: 8,
+  });
+  assert.equal(res.tasks.length, 3);  // final result trimmed to limit
+  assert.ok(sawCandidates > 3);       // reranker saw the wider pool
+  assert.equal(res.reranked, true);
+});
+
+test('a custom reranker reorders the final results', async () => {
+  const corpus = [
+    { id: 'a', title: 'alpha deploy', content: '', projectId: 'p', tags: [] },
+    { id: 'b', title: 'beta deploy', content: '', projectId: 'p', tags: [] },
+    { id: 'c', title: 'gamma deploy', content: '', projectId: 'p', tags: [] },
+  ];
+  const load = async () => ({ corpus, fromCache: false, ageMs: null });
+  const plain = await find('deploy', { loadCorpus: load, limit: 3, includeNative: false });
+  const rr = await find('deploy', { loadCorpus: load, limit: 3, includeNative: false, rerank: async (_q, docs) => [...docs].reverse() });
+  assert.deepEqual(rr.tasks.map((t) => t.id), plain.tasks.map((t) => t.id).reverse());
+});
+
+test('a failing reranker degrades gracefully and keeps the fused results', async () => {
+  const res = await find('ffmpeg', { adapter: fakeAdapter, cache: false, rerank: async () => { throw new Error('reranker oom'); } });
+  assert.equal(res.degraded, true);
+  assert.ok(res.warnings.some((w) => w.includes('rerank') && w.includes('oom')));
+  assert.ok(res.tasks.length > 0); // fell back to fused order, still returns results
 });

--- a/packages/core/test/usage-log.test.js
+++ b/packages/core/test/usage-log.test.js
@@ -1,0 +1,42 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { summarize } from '../usage-log.js';
+
+test('summarize computes per-tool volume, rates, and latency', () => {
+  const entries = [
+    { ts: '2026-07-19T10:00:00Z', tool: 'find', query: 'a', queryLen: 1, resultCount: 3, durationMs: 100, pid: 1, meta: { degraded: false } },
+    { ts: '2026-07-19T10:00:10Z', tool: 'find', query: 'b', queryLen: 1, resultCount: 0, durationMs: 300, pid: 1, meta: { degraded: true } },
+    { ts: '2026-07-19T10:05:00Z', tool: 'similar', query: 'x', queryLen: 1, resultCount: 2, durationMs: 50, pid: 2, error: null },
+  ];
+  const s = summarize(entries, { reQueryMs: 60_000 });
+  assert.equal(s.totalCalls, 3);
+
+  const find = s.perTool.find((t) => t.tool === 'find');
+  assert.equal(find.calls, 2);
+  assert.equal(find.emptyRate, 0.5);      // one of two find calls returned nothing
+  assert.equal(find.degradedRate, 0.5);   // one of two was degraded
+  assert.equal(find.avgMs, 200);          // (100 + 300) / 2
+  assert.equal(find.p95Ms, 300);
+
+  // pid 1 issued two finds 10s apart → exactly one re-query pair.
+  assert.equal(s.reQueries.length, 1);
+  assert.equal(s.reQueries[0].to.query, 'b');
+
+  // top queries include the repeated + singleton entries.
+  assert.ok(s.topQueries.some((q) => q.tool === 'find' && q.query === 'a' && q.count === 1));
+});
+
+test('summarize handles an empty log', () => {
+  const s = summarize([]);
+  assert.equal(s.totalCalls, 0);
+  assert.deepEqual(s.perTool, []);
+  assert.deepEqual(s.reQueries, []);
+  assert.deepEqual(s.topQueries, []);
+});
+
+test('summarize leaves latency null when no durations were recorded', () => {
+  const s = summarize([{ ts: '2026-07-19T10:00:00Z', tool: 'find', query: 'a', queryLen: 1, resultCount: 1, pid: 1 }]);
+  assert.equal(s.perTool[0].avgMs, null);
+  assert.equal(s.perTool[0].p95Ms, null);
+});

--- a/packages/core/usage-log.js
+++ b/packages/core/usage-log.js
@@ -36,6 +36,7 @@ function ensureDir() {
  *   query       — string actually issued to the tool
  *   resultCount — number of results returned
  *   topId       — fullId of the top-1 result, or null
+ *   durationMs  — wall-clock the call took, if the caller measured it
  *   error       — error message if the call failed, else null
  *   meta        — optional small object for tool-specific extras
  */
@@ -50,6 +51,7 @@ export function record(entry) {
     queryTokens: (entry.query || '').split(/\s+/).filter(Boolean).length,
     resultCount: entry.resultCount,
     topId: entry.topId || null,
+    durationMs: typeof entry.durationMs === 'number' ? entry.durationMs : null,
     error: entry.error || null,
     meta: entry.meta || null,
     pid: process.pid,
@@ -63,4 +65,113 @@ export function record(entry) {
 
 export function logPath() {
   return LOG_PATH;
+}
+
+/**
+ * Read + parse the usage log, optionally filtered to a time window.
+ * @param {{since?:Date}} [opts]
+ * @returns {Array<object>} parsed entries, in written order
+ */
+export function readEntries({ since } = {}) {
+  let raw;
+  try {
+    raw = fs.readFileSync(LOG_PATH, 'utf8');
+  } catch {
+    return [];
+  }
+  return raw
+    .split('\n')
+    .filter((l) => l.trim())
+    .map((l) => {
+      try { return JSON.parse(l); } catch { return null; }
+    })
+    .filter(Boolean)
+    .filter((e) => !since || new Date(e.ts) >= since);
+}
+
+function round2(n) {
+  return Math.round(n * 100) / 100;
+}
+
+function median(values) {
+  if (values.length === 0) return 0;
+  const s = [...values].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m] : Math.round((s[m - 1] + s[m]) / 2);
+}
+
+function percentile(values, p) {
+  if (values.length === 0) return 0;
+  const s = [...values].sort((a, b) => a - b);
+  const idx = Math.max(0, Math.min(s.length - 1, Math.ceil((p / 100) * s.length) - 1));
+  return s[idx];
+}
+
+/**
+ * Summarize usage entries into a stats object: per-tool volume, empty/error/
+ * degraded rates, latency (avg + p95), re-query pairs (a proxy for "the first
+ * result was bad"), and top queries. Pure and side-effect-free so the CLI
+ * (`ats usage`) can emit it as JSON and the bench script can render it as
+ * markdown from the SAME analysis.
+ *
+ * @param {Array<object>} entries
+ * @param {{reQueryMs?:number, topN?:number}} [opts]
+ * @returns {object} { totalCalls, perTool, reQueries, topQueries, logPath }
+ */
+export function summarize(entries, { reQueryMs = 60_000, topN = 10 } = {}) {
+  const byTool = {};
+  for (const e of entries) {
+    const t = e.tool || 'unknown';
+    const s = byTool[t] || (byTool[t] = { tool: t, calls: 0, empty: 0, errors: 0, degraded: 0, totalResults: 0, queryLens: [], durations: [] });
+    s.calls++;
+    if (e.error) s.errors++;
+    else if ((e.resultCount || 0) === 0) s.empty++;
+    if (e.meta && e.meta.degraded) s.degraded++;
+    s.totalResults += e.resultCount || 0;
+    s.queryLens.push(e.queryLen || 0);
+    if (typeof e.durationMs === 'number') s.durations.push(e.durationMs);
+  }
+
+  const perTool = Object.values(byTool)
+    .sort((a, b) => b.calls - a.calls)
+    .map((s) => ({
+      tool: s.tool,
+      calls: s.calls,
+      emptyRate: round2(s.empty / s.calls),
+      errorRate: round2(s.errors / s.calls),
+      degradedRate: round2(s.degraded / s.calls),
+      avgResults: round2(s.totalResults / s.calls),
+      medianQueryLen: median(s.queryLens),
+      avgMs: s.durations.length ? Math.round(s.durations.reduce((a, b) => a + b, 0) / s.durations.length) : null,
+      p95Ms: s.durations.length ? percentile(s.durations, 95) : null,
+    }));
+
+  // Re-query within a window, per caller (pid): a fresh search soon after a
+  // previous one is a proxy for "the first result wasn't good enough."
+  const sorted = [...entries].sort((a, b) => new Date(a.ts) - new Date(b.ts));
+  const lastByPid = new Map();
+  const reQueries = [];
+  for (const e of sorted) {
+    const last = lastByPid.get(e.pid);
+    if (last) {
+      const dtMs = new Date(e.ts) - new Date(last.ts);
+      if (dtMs <= reQueryMs) reQueries.push({ from: { tool: last.tool, query: last.query }, to: { tool: e.tool, query: e.query }, dtMs });
+    }
+    lastByPid.set(e.pid, e);
+  }
+
+  const qFreq = {};
+  for (const e of entries) {
+    const k = `${e.tool}|${(e.query || '').toLowerCase()}`;
+    qFreq[k] = (qFreq[k] || 0) + 1;
+  }
+  const topQueries = Object.entries(qFreq)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, topN)
+    .map(([k, n]) => {
+      const sep = k.indexOf('|');
+      return { tool: k.slice(0, sep), query: k.slice(sep + 1), count: n };
+    });
+
+  return { totalCalls: entries.length, perTool, reQueries, topQueries, logPath: LOG_PATH };
 }


### PR DESCRIPTION
Five focused improvements that make ATS's memory more trustworthy and observable. Each extends existing infrastructure (RRF fuse, corpus cache, usage log, typed links, adapter auth) rather than rewriting it. Full CI green — `npm test`: lint + pii + claims + 239 fast tests + all `prove:*` suites.

## What's in it

### 1. Degraded-retrieval transparency
`find` now signals when a result is partial instead of silently serving a subset.
- New top-level `degraded` boolean + `warnings[]` + `corpus.sourcesFailed[]`.
- A dropped corpus source (a composite child that errored, or a single project that failed to list) and a retrieval branch that errored/timed out roll up into that signal.
- The composite adapter records which child it dropped (was: `Promise.allSettled` silently filtered failures away).
- A known-partial corpus is no longer written to the cache as if it were complete.

### 2. Optional reranking
`find` gains a second-stage reranker over the RRF-fused pool.
- `rerank: true` → built-in, dependency-free lexical scorer (query-term coverage + title/phrase weighting). Or pass a function to plug a cross-encoder/LLM.
- Fuses a wider `rerankDepth` pool, then trims to `limit`. A failing reranker degrades to the fused order (surfaced via `degraded`).
- CLI: `ats find "q" --rerank [--rerank-depth N]`.

### 3. Usage observability
- Retrieval calls now log `durationMs`.
- New `ats usage` (`--json`, or markdown) reports per-tool volume, empty/error/degraded rates, latency (avg + p95), re-query pairs, and top queries.
- The analysis lives in one core `summarize()` shared by the CLI and `bench/analyze-usage`, so both agree by construction.

### 4. Duplicate / contradiction detection
- New `ats dedup`: scans the corpus for near-duplicate task clusters (dependency-free Jaccard over title + content + tags, transitively grouped) and flags field-level disagreements (status/priority/due) within a cluster as potential contradictions.
- Detection only — it never edits. Pairs with the existing `conflicts-with` / `supersedes` link types (the action you take on a finding).

### 5. Reactive token refresh
- The TickTick adapter refreshes its OAuth token and retries once on a `401` — the revoked / invalidated-early / wrong-stored-expiry cases the existing proactive clock-based refresh misses — then surfaces an actionable "run `ats auth login`".

## Tests
+19 new tests (retrieval `degraded`/rerank, usage `summarize`, dedup, 401-retry). Full fast suite: 239 pass. `npm test` (incl. lint / pii / claims / prove:*) green.

## Notes for review
- Two originally-scoped items were dropped after reading the code: an MCP-server HTTP/OAuth transport (out of scope — ATS is CLI-first) and a corpus delta-sync (re-embedding is already content-hash cached in `embedding.js`, and a true fetch-delta is blocked by the TickTick Open API v1 having no modified-since endpoint).
- Version not bumped and nothing published — review-only. CHANGELOG entry added under `## 0.10.0 - Unreleased`.
