### PR TITLE
ci: bump actions/setup-node from 4 to 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         node-version: [20, 22]
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies


### PR DESCRIPTION
Supersedes #16, which conflicted with the `actions/checkout` bump after that one merged first. Same change, rebased by hand.