### PR TITLE
fix(adapter-ticktick): authenticate against a key-protected Qdrant

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -78,6 +78,7 @@ curl https://ats-mcp.onrender.com/healthz   # -> {"ok":true,"service":"ats-mcp"}
 | `ATS_MCP_TOKEN` | Render (generated) | The bearer token your agent must send. |
 | `ATS_ADAPTER` | blueprint | Which task system to expose (default `@reneza/ats-adapter-ticktick`). |
 | `QDRANT_HOST` / `OLLAMA_HOST` | `fromService` | Private hostnames of the two backend services; the entrypoint composes `QDRANT_URL` / `OLLAMA_URL` from them. |
+| `QDRANT_API_KEY` | you (optional) | Required only if Qdrant runs with `QDRANT__SERVICE__API_KEY`. Without it every Qdrant path except `/` answers 401 and the vector index reports as unavailable. Sent to Qdrant only, never to Ollama. |
 | `TICKTICK_ACCESS_TOKEN` | you (optional) | Your task-system token. Paste it to make the server read your real tasks. |
 | `TICKTICK_CLIENT_ID` / `TICKTICK_CLIENT_SECRET` | you (optional) | Only needed if you want the token to auto-refresh. A long-lived Open API token does not. |
 

--- a/packages/adapter-ticktick/embedding.js
+++ b/packages/adapter-ticktick/embedding.js
@@ -21,6 +21,7 @@ import { homedir } from 'node:os';
 // --- Configuration ---
 
 const QDRANT_URL = process.env.QDRANT_URL || 'http://localhost:6333';
+const QDRANT_API_KEY = process.env.QDRANT_API_KEY || '';
 const OLLAMA_URL = process.env.OLLAMA_URL || 'http://localhost:11434';
 const EMBEDDING_MODEL = process.env.EMBEDDING_MODEL || 'nomic-embed-text';
 const COLLECTION_NAME = process.env.ATS_TICKTICK_VECTOR_COLLECTION || 'ticktick_tasks';
@@ -50,6 +51,13 @@ async function httpJson(url, method = 'GET', body = undefined, timeoutMs = 30000
       headers: { 'Content-Type': 'application/json' },
       signal: controller.signal,
     };
+    // A Qdrant started with QDRANT__SERVICE__API_KEY answers 401 on every path but
+    // '/', so an unauthenticated client reads as "down" rather than "refused".
+    // Scoped to Qdrant on purpose: httpJson also talks to Ollama, which must never
+    // receive the key.
+    if (QDRANT_API_KEY && url.startsWith(QDRANT_URL)) {
+      opts.headers['api-key'] = QDRANT_API_KEY;
+    }
     if (body !== undefined) opts.body = JSON.stringify(body);
     const res = await fetch(url, opts);
     const text = await res.text();
@@ -169,8 +177,22 @@ async function saveMeta(meta) {
 export async function checkHealth() {
   try {
     await httpJson(`${QDRANT_URL}/collections`, 'GET', undefined, 5000);
-  } catch {
-    return { available: false, reason: `Qdrant not reachable at ${QDRANT_URL}` };
+  } catch (err) {
+    // Distinguish "down" from "refusing you". A blanket "not reachable" on a 401
+    // sends you hunting ports and containers while the service is up and simply
+    // wants QDRANT_API_KEY — that misdiagnosis is the whole reason this branch
+    // reports the status code.
+    const status = /\s(\d{3}):/.exec(err?.message || '')?.[1];
+    if (status === '401' || status === '403') {
+      return {
+        available: false,
+        reason: `Qdrant at ${QDRANT_URL} rejected the request (${status}) — set QDRANT_API_KEY`,
+      };
+    }
+    return {
+      available: false,
+      reason: `Qdrant not reachable at ${QDRANT_URL}${status ? ` (HTTP ${status})` : ''}`,
+    };
   }
   try {
     await httpJson(`${OLLAMA_URL}/api/tags`, 'GET', undefined, 5000);

--- a/packages/adapter-ticktick/test/qdrant-auth.test.js
+++ b/packages/adapter-ticktick/test/qdrant-auth.test.js
@@ -1,0 +1,77 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// QDRANT_URL / QDRANT_API_KEY are captured at module load, so the environment has
+// to be in place before the dynamic import below.
+process.env.QDRANT_URL = 'http://qdrant.test:6333';
+process.env.OLLAMA_URL = 'http://ollama.test:11434';
+process.env.QDRANT_API_KEY = 'test-key';
+
+const { checkHealth } = await import('../embedding.js');
+
+function stubFetch(handler) {
+  const original = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async (url, opts = {}) => {
+    calls.push({ url, headers: opts.headers || {} });
+    return handler(url);
+  };
+  return {
+    calls,
+    restore() {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+const ok = async () => ({ ok: true, status: 200, text: async () => '{}' });
+
+test('the Qdrant API key is sent to Qdrant and withheld from Ollama', async () => {
+  const stub = stubFetch(ok);
+  try {
+    const health = await checkHealth();
+    assert.equal(health.available, true);
+
+    const qdrant = stub.calls.find((c) => c.url.startsWith('http://qdrant.test:6333'));
+    const ollama = stub.calls.find((c) => c.url.startsWith('http://ollama.test:11434'));
+
+    assert.ok(qdrant, 'expected a Qdrant request');
+    assert.ok(ollama, 'expected an Ollama request');
+    assert.equal(qdrant.headers['api-key'], 'test-key');
+    // The same helper talks to both services; the credential must not follow.
+    assert.equal(ollama.headers['api-key'], undefined);
+  } finally {
+    stub.restore();
+  }
+});
+
+test('a 401 from Qdrant reports an auth problem, not an unreachable service', async () => {
+  const stub = stubFetch(async (url) =>
+    url.startsWith('http://qdrant.test:6333')
+      ? { ok: false, status: 401, text: async () => 'Unauthorized' }
+      : ok()
+  );
+  try {
+    const health = await checkHealth();
+    assert.equal(health.available, false);
+    assert.match(health.reason, /401/);
+    assert.match(health.reason, /QDRANT_API_KEY/);
+    assert.doesNotMatch(health.reason, /not reachable/);
+  } finally {
+    stub.restore();
+  }
+});
+
+test('a genuinely unreachable Qdrant still reports as unreachable', async () => {
+  const stub = stubFetch(async (url) => {
+    if (url.startsWith('http://qdrant.test:6333')) throw new Error('connect ECONNREFUSED');
+    return ok();
+  });
+  try {
+    const health = await checkHealth();
+    assert.equal(health.available, false);
+    assert.match(health.reason, /not reachable/);
+  } finally {
+    stub.restore();
+  }
+});


### PR DESCRIPTION
## What

`httpJson` now sends an `api-key` header when `QDRANT_API_KEY` is set, and `checkHealth()` tells an auth refusal apart from an unreachable service.

## Why

A Qdrant started with `QDRANT__SERVICE__API_KEY` answers **401 on every path except `/`**. The adapter sent no credential, so `checkHealth()` hit its catch-all and reported *"Qdrant not reachable at http://localhost:6333"* — for a service that was up and simply refusing the request.

That misdiagnosis is the expensive part. `ats doctor` said "not reachable", which sends you hunting ports, containers and firewall rules while the fix is one environment variable. Meanwhile retrieval silently degraded to keyword-only: every query still returned results, just worse ones, with no error anywhere.

## Notes

- The header is scoped with `url.startsWith(QDRANT_URL)` deliberately — the same helper also calls Ollama, which must never receive the key.
- No default is invented: with `QDRANT_API_KEY` unset the behaviour is byte-for-byte what it was.
- `deploy/README.md` documents the variable alongside the existing Qdrant/Ollama entries.

## Tests

Three cases in `packages/adapter-ticktick/test/qdrant-auth.test.js`: the key reaches Qdrant, it does **not** leak to Ollama, and a genuine connection failure still reports as unreachable.

`npm run lint`, `check:pii`, `check:claims` clean · `test:fast` 299/299.

## Release

Versions are untouched — packages here move in lockstep (`0.7.1 → 0.8.0 → 0.8.1 → 0.9.0 → 0.10.0`), so the bump belongs to a deliberate release, not this PR.
