### PR TITLE
fix(deps): override ip-address to ^10.3.1 (CVE-2026-69192)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1276,9 +1276,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "@eslint/js": "^10.0.1",
     "eslint": "^10.9.1",
     "husky": "^9.1.7"
+  },
+  "overrides": {
+    "ip-address": "^10.3.1"
   }
 }


### PR DESCRIPTION
Pulls the transitive `ip-address` dependency off a vulnerable version.

### Affected advisories

`ip-address@10.2.0` reaches us via `@modelcontextprotocol/sdk` → `express-rate-limit`, and is in range for three advisories:

| Advisory | CVE | Severity | Patched |
|---|---|---|---|
| GHSA-mwp4-54f8-5fhr | CVE-2026-69192 | HIGH | 10.3.1 |
| GHSA-4xrf-jv44-h6hh | CVE-2026-69198 | MEDIUM | 10.2.2 |
| GHSA-22jq-vg5j-6vgg | CVE-2026-54272 | MEDIUM | 10.2.1 |

The HIGH one: `Address4` decodes leading-zero octets as decimal while resolvers decode them as octal, allowing SSRF and trust-boundary bypass.

### Why an override

`@modelcontextprotocol/sdk@1.30.0` is already the current release and still declares `express-rate-limit@8.5.2`, so there is no upstream bump to take. An npm `overrides` entry is the only route — and it is not something Dependabot can author, which is why this sat unflagged.

### Why a range and not a pin

`^10.3.1` rather than an exact pin, so our own override does not block future patches — three advisories landed on this package in August alone. Resolves to **10.7.0**, which satisfies `express-rate-limit`'s declared `^10.2.0`.

### Verification

- Lockfile integrity hash checked against the npm registry tarball for 10.7.0.
- `npm ls ip-address` confirms a single resolved copy at 10.7.0, no duplicates.
- Full `npm test` green locally.

Supersedes #25, which proposed the same upgrade as a hard pin at 10.3.1.