### PR TITLE
workstream: scaffold and gate work streams inside ats

### DIFF
--- a/docs/workstreams.md
+++ b/docs/workstreams.md
@@ -56,8 +56,33 @@ formatter shows the task line alone.
 `::colon highlight::` is the primary marker — one per section, on the single
 value the eye should land on. Bold carries titles, `` `code` `` carries
 commands, `- [ ]` carries the verification log, `> ` carries the outcome.
-`ATS_WORKSTREAM_HIGHLIGHT` overrides the token for a store that renders
-something else.
+
+### The colour standard
+
+Colour is **derived from gate state, never chosen**. That is what makes the rule
+safe to keep: every colour is a state the command already computes, so nothing
+has to be remembered, and a body re-renders to the same colours every time. A
+scheme where a human or an agent picks the colour is a scheme that rots.
+
+| role | colour | means |
+|---|---|---|
+| `outcome` | cyan | what must become true: the stream outcome, an item's done-when |
+| `date` | yellow | the review date, when it lands in front of the human |
+| `pass` | green | verified with evidence, safe to hand back |
+| `fail` | red | failed or blocked, needs a decision |
+
+Blue and purple are deliberately unassigned. An unused colour keeps its signal;
+spending all six on nothing in particular is how a scheme goes numb.
+
+The roles live in `MARKUP` at the top of `packages/cli/workstream.js`, which is
+the single place to change. Each is overridable by env var
+(`ATS_HL_OUTCOME`, `ATS_HL_DATE`, `ATS_HL_PASS`, `ATS_HL_FAIL`), and
+`ATS_WORKSTREAM_HIGHLIGHT` overrides all of them for a store that renders
+something else entirely.
+
+`ats workstream rerender <id>` applies a template or colour change to every body
+in an existing stream, rebuilding them from the intent metadata and the ledger.
+Bodies are never edited in the app.
 
 ## Adapter capabilities this relies on
 

--- a/docs/workstreams.md
+++ b/docs/workstreams.md
@@ -1,0 +1,89 @@
+# Work streams
+
+`ats workstream` scaffolds and gates a **work stream**: one parent task plus
+**2-3 sub-tasks**, each carrying a review date and a named verification.
+Nothing goes back to the human until `ats workstream ready <id>` exits 0.
+
+The premise is that the human's capacity to process information is limited, so
+what reaches them has to be small, scannable, dated, and already verified. The
+command makes that structural instead of a matter of agent discipline.
+
+## The loop
+
+```bash
+ats workstream template > stream.json     # strict spec, fill it in
+ats workstream lint stream.json           # exit 2 until the spec is clean
+ats workstream create stream.json         # parent + 2-3 real sub-tasks
+# ... do the work ...
+ats workstream verify <stream> <n> --evidence "<what you actually observed>"
+ats workstream ready <stream>             # exit 0 ONLY when every item passed
+```
+
+Exit codes: `0` ok, `1` error, `2` gate failed.
+
+## The five rules, all enforced
+
+1. **Max 3 work items per stream.** A fourth is refused; split instead.
+2. **Every work item carries a review date**, re-read live on every check, so a
+   date cleared in the app turns the gate red.
+3. **Every work item names its verification** before the work starts.
+4. **Titles name an outcome, not an activity.** Container verbs are rejected.
+5. **Bodies are rendered from the spec**, never hand-authored.
+
+`ats workstream ready` exiting 0 is the only permission to hand a stream back.
+A `--fail` verification is a legitimate result; it keeps the gate red.
+Evidence means a reading, not an opinion: `pytest -q -> 34 passed in 2.1s`, not
+`tests pass`.
+
+## It stores nothing of its own
+
+| what | where it lives |
+|---|---|
+| stream membership | real sub-tasks (`parentId`) + `hierarchy` metadata |
+| outcome, done-when, the verify command | `intent` metadata (`outcome`, `doneWhen`, `authority`) |
+| the verification log | the append-only action ledger |
+| the review date | the task due date |
+
+So `ats intent get`, `ats hierarchy get`, `ats ledger list` and `ats undo` all
+work on a work stream as an ordinary ATS task graph. There is no private store
+and no second interface: a work stream is an ATS operation.
+
+Note that `ats intent get` renders intent only under `--format json`; the text
+formatter shows the task line alone.
+
+## Readability
+
+`::colon highlight::` is the primary marker — one per section, on the single
+value the eye should land on. Bold carries titles, `` `code` `` carries
+commands, `- [ ]` carries the verification log, `> ` carries the outcome.
+`ATS_WORKSTREAM_HIGHLIGHT` overrides the token for a store that renders
+something else.
+
+## Adapter capabilities this relies on
+
+Added 2026-09-07, all additive, defaults unchanged:
+
+- **`tasks create --parent <id>`** — a real nested sub-task. Previously
+  `ats hierarchy set` only wrote a `## Related` link into the description while
+  the adapter's `parentId` stayed null.
+- **`tasks get|update --live`** — bypass the local cache. Cached reads are the
+  right default for retrieval and the wrong basis for a gate: a review date
+  cleared in the app would go unseen. On update it also drops the cached merge
+  base so a concurrent app-side edit is not clobbered. An explicit `--live`
+  overrides `ATS_TICKTICK_LOCAL_DETAILS_ONLY`.
+- **`tasks create|update --raw`** — store the body verbatim, skipping
+  `normalizeTaskBody`, so a deterministically rendered body survives the write.
+- The TickTick adapter now surfaces **`parentId` and `childIds`**, which its
+  task mapping previously dropped, making a parent's children invisible.
+
+## Gotchas the command already handles
+
+- A bare `YYYY-MM-DD` is stored by TickTick as *no date*; every date is sent as
+  a full ISO stamp.
+- TickTick resets any field omitted from an update body, so updates are
+  read-merge-write.
+- Item order is sorted by creation time, not by `childIds` order, because
+  `verify <n>` addresses an item by position and an unstable order would verify
+  the wrong item.
+- The ledger filter keys are `projectId`/`taskId`; the scoping is re-asserted
+  locally so one item's PASS can never satisfy another.

--- a/packages/adapter-ticktick-cache/index.js
+++ b/packages/adapter-ticktick-cache/index.js
@@ -356,7 +356,12 @@ export function createTickTickCacheAdapter(options = {}) {
 
   const tasks = {
     list: (projectRef) => operations.tasks.list(projectRef, cacheDeps),
-    get: async (projectRef, taskRef) => {
+    get: async (projectRef, taskRef, opts = {}) => {
+      // An explicit --live is a deliberate request for ground truth, so it
+      // overrides ATS_TICKTICK_LOCAL_DETAILS_ONLY. Default reads are untouched.
+      if (opts.live && remote.__ext?.tasks?.get) {
+        return remote.__ext.tasks.get(projectRef, taskRef);
+      }
       let cached;
       try {
         cached = tasksForProject(load(), projectRef).find((item) => taskMatches(item, taskRef));
@@ -386,8 +391,13 @@ export function createTickTickCacheAdapter(options = {}) {
       });
       return result;
     },
-    update: async (projectId, taskId, patch = {}) => {
-      const cached = tasksForProject(load(), projectId).find((item) => taskMatches(item, taskId));
+    update: async (projectId, taskId, patch = {}, opts = {}) => {
+      // TickTick resets omitted fields, so the update needs a merge base. The
+      // cache is the fast one; with { live: true } the remote adapter fetches
+      // the task itself, so a concurrent change in the app is not clobbered.
+      const cached = opts.live
+        ? null
+        : tasksForProject(load(), projectId).find((item) => taskMatches(item, taskId));
       const result = await remote.__ext.tasks.update(
         projectId,
         taskId,
@@ -535,10 +545,30 @@ export function createTickTickCacheAdapter(options = {}) {
       });
       return JSON.parse(output);
     }
-    if (typeof operations.tasks.vectorSync !== 'function') {
-      throw new Error('The active TickTick adapter does not provide vector synchronization');
-    }
-    return operations.tasks.vectorSync(opts);
+    // Index from the local cache, not the remote Open API project fan-out.
+    // GET /project has no Inbox, so the fan-out silently left ~250 Inbox tasks
+    // (and everything else the cache holds but /project/{id}/data omits) out of
+    // semantic search. Ids here are full TickTick ids, identical to the
+    // payload.taskId keys already in Qdrant, so this re-uses the existing index.
+    const fetchAllTasks = async () => load().tasks
+      .filter((task) => task.status !== 2)
+      .map((task) => ({
+        id: task.id,
+        title: task.title || '',
+        content: task.content || '',
+        projectId: task.projectId,
+        projectName: task.projectName,
+        priority: task.priority || 'none',
+        tags: task.tags || [],
+        dueDate: task.dueDate || null,
+      }));
+    // `embedder`, not the module import: options.embedding is the injection seam
+    // every other vector call already uses, and bypassing it here made syncVectors
+    // untestable and silently ignored an injected embedder.
+    return embedder.sync(fetchAllTasks, {
+      forceFull: !!opts.forceFull,
+      maxEmbeddings: Number(opts.maxEmbeddings) || 200,
+    });
   }
 
   let adapter;

--- a/packages/adapter-ticktick-cache/test/cache.test.js
+++ b/packages/adapter-ticktick-cache/test/cache.test.js
@@ -254,23 +254,35 @@ test('cache sync leaves the last good centralized JSON untouched when any projec
   assert.equal(fs.readFileSync(cacheFile, 'utf8'), before);
 });
 
-test('vector sync fallback delegates to the ATS TickTick adapter without a legacy CLI', async () => {
+test('vector sync indexes from the local cache, Inbox included, without delegating', async () => {
+  // Regression guard for the 2026-08-30 fix. Vector sync used to delegate to the
+  // remote adapter, which fans out over GET /project - an endpoint that has no
+  // Inbox - so Inbox tasks were silently never indexed. It now reads the local
+  // cache directly, the only source that holds them.
   const cacheFile = fixture();
   const operations = remote().__ext;
-  operations.tasks.vectorSync = async (opts) => ({ success: true, opts, source: 'ats-adapter' });
+  let delegated = false;
+  operations.tasks.vectorSync = async () => { delegated = true; return { success: true }; };
+
+  let seen = null;
+  const embedding = {
+    sync: async (fetchAllTasks, opts) => {
+      seen = await fetchAllTasks();
+      return { success: true, indexed: seen.length, opts };
+    },
+  };
   const adapter = createTickTickCacheAdapter({
-    cacheFile,
-    remote: remote(),
-    operations,
-    embedding: {},
-    vectorSyncScript: '',
+    cacheFile, remote: remote(), operations, embedding, vectorSyncScript: '',
   });
+
   const result = await adapter.__ext.tasks.vectorSync({ forceFull: true, maxEmbeddings: 7 });
-  assert.deepEqual(result, {
-    success: true,
-    opts: { forceFull: true, maxEmbeddings: 7 },
-    source: 'ats-adapter',
-  });
+
+  assert.equal(delegated, false, 'must not delegate to the remote adapter');
+  assert.deepEqual(result.opts, { forceFull: true, maxEmbeddings: 7 });
+  const ids = seen.map((task) => task.id);
+  assert.ok(ids.includes('inboxtask123456789'), 'the Inbox task must reach the index');
+  assert.ok(!ids.includes('completedtask123456789'), 'completed tasks stay out of the index');
+  assert.equal(result.indexed, 3);
 });
 
 test('central vector helper receives --full and --max options', async () => {

--- a/packages/adapter-ticktick/embedding.js
+++ b/packages/adapter-ticktick/embedding.js
@@ -85,7 +85,11 @@ export function truncateText(text, maxCharacters, suffix = '') {
 }
 
 async function getEmbedding(text, inputType = 'document') {
-  const truncated = truncateText(embeddingInput(text, inputType), 8000);
+  // 8000 chars overruns the embedder's context on dense text (German, technical,
+  // long task logs) and ollama answers 500 - which the caller counted as a silent
+  // error, leaving 33 of the largest tasks out of the index. 4000 embeds reliably.
+  const truncated = truncateText(embeddingInput(text, inputType),
+    Number(process.env.EMBEDDING_MAX_CHARS) || 4000);
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     try {
       const data = await httpJson(

--- a/packages/adapter-ticktick/index.js
+++ b/packages/adapter-ticktick/index.js
@@ -48,6 +48,7 @@ const adapter = {
       content: input.content,
       tags: input.tags,
       dueDate: input.dueDate,
+      parentId: input.parentId,
     });
     return contractTask(r.task, input);
   },

--- a/packages/adapter-ticktick/tasks.js
+++ b/packages/adapter-ticktick/tasks.js
@@ -41,6 +41,8 @@ export async function list(projectId, deps = {}) {
     priority: formatPriority(t.priority),
     tags: t.tags || [],
     kind: t.kind || 'TEXT',         // TASK | NOTE — TickTick distinguishes; surface it
+    parentId: t.parentId,
+    childIds: t.childIds || [],
     status: t.status === 2 ? 'completed' : 'active',
     completedTime: t.completedTime,
     modifiedTime: t.modifiedTime,
@@ -85,6 +87,10 @@ export async function get(projectId, taskId, deps = {}) {
     reminders: task.reminders,
     repeatFlag: task.repeatFlag,
     items: task.items,
+    // Sub-task edges. TickTick returns both; the mapping used to drop them,
+    // so a parent's children were invisible to every caller.
+    parentId: task.parentId,
+    childIds: task.childIds || [],
     attachments: task.attachments || [],
     createdTime: task.createdTime,
     modifiedTime: task.modifiedTime,
@@ -114,6 +120,9 @@ export async function create(projectId, title, options = {}, deps = {}) {
   const input = { title: title.trim(), projectId: resolvedProjectId };
 
   if (options.content !== undefined) input.content = options.content;
+  // A real TickTick sub-task: the Open API accepts parentId on create, though
+  // the create response does not echo it back (the readback does).
+  if (options.parentId !== undefined) input.parentId = options.parentId;
   if (options.dueDate !== undefined) input.dueDate = normalizeDue(options.dueDate);
   if (options.priority !== undefined) input.priority = parsePriority(options.priority);
   if (options.tags !== undefined) input.tags = Array.isArray(options.tags) ? options.tags : options.tags.split(',').map((t) => t.trim()).filter(Boolean);

--- a/packages/cli/bin/ats.js
+++ b/packages/cli/bin/ats.js
@@ -21,6 +21,7 @@ import {
   getMainHelp,
   getNotesHelp,
   getTasksHelp,
+  getWorkstreamHelp,
   getAuthHelp,
   getProjectsHelp,
   getAdapterHelp,
@@ -283,6 +284,30 @@ async function main() {
       case 'tasks':
         result = await handleTasks();
         break;
+      case 'workstream': {
+        // Work streams: the 3-item cap, review dates and the verification gate.
+        // It stores nothing of its own - membership is real sub-tasks, intent
+        // metadata carries outcome/done-when, and the action ledger is the
+        // verification log - so it is an ATS operation, not a second interface.
+        const { runWorkstream } = await import('../workstream.js');
+        const wsAdapter = await loadAdapter();
+        process.exit(await runWorkstream({
+          adapter: wsAdapter,
+          args,
+          readSpec: (file) => {
+            if (!file) { console.error('Usage: ats workstream <lint|create> SPEC.json'); process.exit(1); }
+            const raw = file === '-' ? fs.readFileSync(0, 'utf8') : fs.readFileSync(file, 'utf8');
+            try { return JSON.parse(raw); } catch (e) {
+              console.error(`ats workstream: spec is not valid JSON: ${e.message}`);
+              process.exit(1);
+            }
+          },
+          urlFor: (projectId, taskId) => (wsAdapter.urlFor
+            ? wsAdapter.urlFor({ projectId, taskId })
+            : `${projectId}/${taskId}`),
+        }));
+        break;
+      }
       case 'notes':
         result = await handleNotes();
         break;
@@ -496,6 +521,7 @@ function helpFor(command) {
     case 'auth': return getAuthHelp();
     case 'projects': return getProjectsHelp();
     case 'tasks': return getTasksHelp();
+    case 'workstream': return getWorkstreamHelp();
     case 'notes': return getNotesHelp();
     case 'adapter': return getAdapterHelp();
     case 'open': return getOpenHelp();
@@ -1327,7 +1353,12 @@ async function handleTasks() {
     case 'get': {
       if (!args.positional[0] || !args.positional[1]) { console.error('Usage: ats tasks get PROJECT_ID TASK_ID'); process.exit(1); }
       const [gp, gid] = args.positional;
-      const got = t?.get ? await t.get(gp, gid) : await adapter.getTask(gp, gid);
+      // --live bypasses the local cache. A gate decided on a cached read is not
+      // a gate; the cache stays the default for retrieval.
+      const live = args.options.live === true;
+      const got = t?.get
+        ? await t.get(gp, gid, ...(live ? [{ live: true }] : []))
+        : await adapter.getTask(gp, gid);
       if (args.options['no-format'] === true || process.env.ATS_GET_NOFORMAT) return withContentHash(got);
       return withContentHash(await formatTriageOnGet(t, adapter, gp, gid, got));
     }
@@ -1358,6 +1389,7 @@ async function handleTasks() {
         priority: args.options.priority,
         tags: args.options.tags,
         reminder: args.options.reminder,
+        parentId: args.options.parent,
       };
       if (!title && process.stdin.isTTY && adapter.__ext?.interactive?.promptTaskCreate) {
         const input = await adapter.__ext.interactive.promptTaskCreate({ projectId, title, ...opts });
@@ -1379,8 +1411,11 @@ async function handleTasks() {
       // Conform any body that's written (deterministic, no LLM). Bare quick-captures
       // (no --content) stay clean; they get the Goal+Log skeleton on first `get`.
       // format-skip.txt projects keep the body verbatim (id-based match — a project
-      // passed by NAME is not recognized by the skip).
-      if (opts.content && !formatSkipped(projectId)) opts.content = normalizeTaskBody(opts.content).content;
+      // passed by NAME is not recognized by the skip). --raw is the per-call form:
+      // a body rendered deterministically by a tool must survive byte-for-byte.
+      if (opts.content && !formatSkipped(projectId) && args.options.raw !== true) {
+        opts.content = normalizeTaskBody(opts.content).content;
+      }
       // Idempotent creates: a key that already produced something returns it;
       // --if-absent returns the active task that already carries this title.
       const idemKey = typeof args.options['idempotency-key'] === 'string' ? args.options['idempotency-key'] : undefined;
@@ -1483,7 +1518,11 @@ async function handleTasks() {
       }
       // Normalize the body whenever content is being written (no extra fetch when it isn't).
       // format-skip.txt projects keep the body verbatim (id-based match).
-      if (patch.content !== undefined && !formatSkipped(up)) patch.content = normalizeTaskBody(patch.content).content;
+      // --raw is the per-call form of format-skip: a body rendered
+      // deterministically by a tool must survive the write byte-for-byte.
+      if (patch.content !== undefined && !formatSkipped(up) && args.options.raw !== true) {
+        patch.content = normalizeTaskBody(patch.content).content;
+      }
       const gate = reviewGate('task.updated', current, {
         projectId: up,
         taskId: uid,
@@ -1492,7 +1531,8 @@ async function handleTasks() {
       });
       if (gate) return gate;
       const result = t?.update
-        ? await t.update(up, uid, patch)
+        ? await t.update(up, uid, patch,
+          ...(args.options.live === true ? [{ live: true }] : []))
         : await adapter.updateTask(up, uid, { ...patch, tags: tagsToArray(patch.tags) });
       auditCliWrite('task.updated', result, { projectId: up, taskId: uid }, {
         fields: Object.keys(patch).filter((key) => patch[key] !== undefined),

--- a/packages/cli/parser.js
+++ b/packages/cli/parser.js
@@ -416,6 +416,7 @@ Commands:
   links <p> <t>  Resolve cross-references inside a task or note
   create <title> Create a task (shortcut for tasks create)
   update <p> <t> Update a task (shortcut for tasks update)
+  workstream     Scaffold + gate a work stream (parent + 2-3 verified sub-tasks)
   hybrid <query> Dense+sparse retrieval (embedder-backed adapters)
   similar <id>   Find related items (embedder-backed adapters)
   intent         Read or set an item's outcome, constraints, and authority
@@ -633,6 +634,41 @@ Every check requires a reason and appends an allow/deny ledger record. ATS is a
 decision point for cooperating clients; it does not sandbox external tools.`,
   };
   return help[command] || getMainHelp();
+}
+
+export function getWorkstreamHelp() {
+  return `ats workstream - one parent task + 2-3 verified sub-tasks
+
+Every work item carries a review date and a named verification. Nothing goes
+back to the human until 'ats workstream ready <id>' exits 0.
+
+Usage: ats workstream <subcommand> [options]
+
+Subcommands:
+  template                 Print the strict spec template
+  lint SPEC.json           Validate a spec - exit 2 until clean, no writes
+  create SPEC.json         Scaffold parent + sub-tasks  [--dry-run]
+  verify ID N --evidence "..." [--fail]
+                           Record a verification result on work item N
+  check ID                 Cap, review dates, verifications  [--json]
+  ready ID                 HARD GATE - exit 0 only if every item passed  [--json]
+  redate ID <n|stream> DATE
+                           Move a review date (task + rendered body together)
+  show ID / list           Live state of one stream / all streams
+  agent-brief              The contract, for any agent
+
+Options:
+  --project <id>           Skip the lane lookup when the stream is not in Inbox
+  --dry-run                (create) Render without writing
+  --evidence <text>        (verify) The reading that proves it, not an opinion
+  --fail                   (verify) Record a failed verification
+
+State lives in ATS primitives, not in a private store: membership is real
+sub-tasks, outcome and done-when are intent metadata, the verification log is
+the action ledger, the review date is the task due date. So 'ats intent get',
+'ats hierarchy get', 'ats ledger list' and 'ats undo' all work on these tasks.
+
+Exit codes: 0 ok, 1 error, 2 gate failed.`;
 }
 
 export function getConfigHelp() {
@@ -992,6 +1028,11 @@ Create/Update options:
   --prepend <text>       (update) Add text before the current body
   --if-match <hash>      (update) Write only while the body still has this
                          contentHash (from 'tasks get'); exit 3 if it changed
+  --parent <task_id>     (create) Make this a sub-task of that task
+  --raw                  Store --content verbatim; skip body normalization
+  --live                 (get/update) Bypass the local cache and read TickTick
+                         directly. On update it also makes the merge base live,
+                         so a concurrent change is not clobbered.
   --relevance            (create) Append a Relevance Rule instruction block
                          after the result so the active agent can
                          decide a trunk and follow up with 'tasks update'.

--- a/packages/cli/parser.js
+++ b/packages/cli/parser.js
@@ -654,6 +654,7 @@ Subcommands:
   ready ID                 HARD GATE - exit 0 only if every item passed  [--json]
   redate ID <n|stream> DATE
                            Move a review date (task + rendered body together)
+  rerender ID              Re-apply the current template to every body
   show ID / list           Live state of one stream / all streams
   agent-brief              The contract, for any agent
 

--- a/packages/cli/test/workstream.test.js
+++ b/packages/cli/test/workstream.test.js
@@ -1,0 +1,136 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { lint, MAX_ITEMS, runWorkstream, EXIT_OK, EXIT_GATE } from '../workstream.js';
+import { recordAction, listActions } from '@reneza/ats-core';
+
+const future = (days = 14) =>
+  new Date(Date.now() + days * 864e5).toISOString().slice(0, 10);
+
+const item = (title, review = future()) => ({
+  title,
+  outcome: 'a deliverable',
+  done_when: 'an observable state',
+  verify: 'the command that proves it',
+  review,
+  notes: '',
+});
+
+const spec = (items, streamTitle = 'Gate fixtures reach the task app') => ({
+  stream: {
+    title: streamTitle,
+    project: 'inbox',
+    outcome: 'the stream outcome',
+    review: future(),
+    tags: ['wstream'],
+  },
+  items,
+});
+
+test('lint accepts a well-formed two-item spec', () => {
+  assert.deepEqual(lint(spec([item('First deliverable lands'), item('Second deliverable lands')])), []);
+});
+
+test('lint enforces the hard cap at three work items', () => {
+  const errs = lint(spec([item('One'), item('Two'), item('Three'), item('Four')]));
+  assert.ok(errs.some((e) => e.includes(`max ${MAX_ITEMS} per stream`)),
+    `expected a cap error, got: ${errs.join(' | ')}`);
+  assert.deepEqual(lint(spec([item('One'), item('Two'), item('Three')])), []);
+});
+
+test('lint rejects an empty item list', () => {
+  assert.ok(lint(spec([])).some((e) => e.includes('at least')));
+});
+
+test('lint rejects container-verb titles on stream and item', () => {
+  const errs = lint(spec([item('work on the manifest')], 'explore the reach gate'));
+  assert.ok(errs.some((e) => e.startsWith('stream.title') && e.includes("'explore'")));
+  assert.ok(errs.some((e) => e.startsWith('items[1].title') && e.includes("'work on'")));
+});
+
+test('lint rejects a review date in the past', () => {
+  const errs = lint(spec([item('Deliverable lands', '2020-01-01')]));
+  assert.ok(errs.some((e) => e.includes('is in the past')));
+});
+
+test('lint rejects unfilled template placeholders and a missing verification', () => {
+  const bare = item('Deliverable lands');
+  bare.verify = '';
+  const s = spec([bare]);
+  s.stream.outcome = '<one sentence, observable when it is true>';
+  const errs = lint(s);
+  assert.ok(errs.some((e) => e.includes('items[1].verify is required')));
+  assert.ok(errs.some((e) => e.includes('stream.outcome is still the template placeholder')));
+});
+
+test('lint rejects a spec that is not shaped like one', () => {
+  assert.equal(lint({}).length, 1);
+  assert.equal(lint(null).length, 1);
+});
+
+// The gate's one unforgivable failure mode: one item's PASS counting for
+// another. This pins the ledger scoping that a mistyped filter key once broke.
+test('a verification recorded on one item never satisfies another', async (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ats-ws-'));
+  const logPath = path.join(dir, 'actions.jsonl');
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  recordAction({
+    action: 'workstream.verify',
+    task: { projectId: 'p1', taskId: 'item-one' },
+    output: 'the reading that proves item one',
+    advanced: true,
+  }, { logPath });
+
+  const forItemOne = listActions({ projectId: 'p1', taskId: 'item-one', action: 'workstream.verify' }, { logPath });
+  const forItemTwo = listActions({ projectId: 'p1', taskId: 'item-two', action: 'workstream.verify' }, { logPath });
+  assert.equal(forItemOne.length, 1);
+  assert.equal(forItemTwo.length, 0, 'item two must not inherit item one\'s verification');
+});
+
+test('the ledger records a failed verification as not advanced', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ats-ws-'));
+  const logPath = path.join(dir, 'actions.jsonl');
+  try {
+    recordAction({
+      action: 'workstream.verify',
+      task: { projectId: 'p1', taskId: 'item-one' },
+      output: 'the command exited 1',
+      advanced: false,
+    }, { logPath });
+    const [entry] = listActions({ projectId: 'p1', taskId: 'item-one' }, { logPath });
+    assert.equal(entry.advanced, false);
+    assert.equal(entry.output, 'the command exited 1');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('template and lint round-trip through the command surface', async () => {
+  const out = [];
+  const args = { subcommand: 'template', positional: [], options: {} };
+  const code = await runWorkstream({
+    adapter: {}, args, readSpec: () => ({}), urlFor: () => '', log: (m) => out.push(m), err: () => {},
+  });
+  assert.equal(code, EXIT_OK);
+  const template = JSON.parse(out.join('\n'));
+  assert.equal(template.items.length, 2);
+  // The shipped template is deliberately unfilled, so it must not pass lint.
+  assert.ok(lint(template).length > 0);
+});
+
+test('lint through the command surface exits 2 on a capped spec', async () => {
+  const args = { subcommand: 'lint', positional: ['ignored.json'], options: {} };
+  const code = await runWorkstream({
+    adapter: {},
+    args,
+    readSpec: () => spec([item('One'), item('Two'), item('Three'), item('Four')]),
+    urlFor: () => '',
+    log: () => {},
+    err: () => {},
+  });
+  assert.equal(code, EXIT_GATE);
+});

--- a/packages/cli/workstream.js
+++ b/packages/cli/workstream.js
@@ -1,0 +1,632 @@
+/**
+ * ats workstream — work streams: one parent task + 2-3 verified sub-tasks.
+ *
+ * The human's capacity to process information is limited, so anything that
+ * reaches them must be small, scannable, dated, and already verified. This
+ * command makes that structural rather than a matter of agent discipline.
+ *
+ * It owns no storage of its own. Everything lives in ATS primitives:
+ *   - membership      real sub-tasks (adapter parentId) + hierarchy metadata
+ *   - outcome/done    intent metadata (frontmatter), not a private body format
+ *   - the verify log  the append-only action ledger
+ *   - the review date the task due date
+ * so `ats intent get`, `ats hierarchy get`, `ats ledger list` and `ats undo`
+ * all see a work stream as an ordinary ATS task graph.
+ */
+
+import {
+  parseTaskMetadata,
+  writeTaskMetadata,
+  recordAction,
+  listActions,
+} from '@reneza/ats-core';
+
+// --- the hard numbers ------------------------------------------------------
+export const MAX_ITEMS = 3;   // "two to three work items max per work stream"
+const MIN_ITEMS = 1;
+const TITLE_MAX = 70;         // a title that still reads on one line
+const STREAM_TAG = 'wstream';
+const VERIFY_ACTION = 'workstream.verify';
+
+// A title built on one of these names an activity, not an outcome.
+const CONTAINER_VERBS = [
+  'do', 'work on', 'explore', 'check in on', 'look into', 'think about',
+  'review', 'investigate', 'research', 'continue', 'start', 'handle',
+  'deal with', 'sort out', 'figure out', 'touch base', 'follow up on',
+];
+
+export const EXIT_OK = 0;
+export const EXIT_ERR = 1;
+export const EXIT_GATE = 2;
+
+// ---------------------------------------------------------------------------
+// readability — ::colon highlight:: is the primary marker, one per section
+// ---------------------------------------------------------------------------
+
+const HL = process.env.ATS_WORKSTREAM_HIGHLIGHT || '::{}::';
+const hl = (text) => HL.replace('{}', String(text).trim().replace(/:+$/, ''));
+const bold = (text) => `**${text}**`;
+const code = (text) => '`' + String(text).replace(/`/g, "'") + '`';
+
+function renderStreamBody(spec, streamId) {
+  const { stream, items } = spec;
+  const lines = [
+    '## Outcome',
+    `> ${hl(stream.outcome)}`,
+    '',
+    `## Work items ${hl(`${items.length} of max ${MAX_ITEMS}`)}`,
+  ];
+  items.forEach((item, i) => {
+    lines.push(`${i + 1}. ${bold(item.title)} ${hl(`review ${day(item.review)}`)}`);
+  });
+  lines.push(
+    '',
+    '## Ready gate',
+    `Back to the human only when ${code(`ats workstream ready ${streamId || '<stream>'}`)} exits 0.`,
+    `Every item needs ${hl('a review date and a PASS with evidence')}.`,
+  );
+  return lines.join('\n');
+}
+
+function renderItemBody(item, n, total, log) {
+  const last = log[log.length - 1];
+  const status = !last
+    ? hl('NOT VERIFIED YET')
+    : last.advanced ? hl('VERIFIED') : hl('VERIFICATION FAILED');
+  const lines = [
+    status,
+    '',
+    '## Outcome',
+    `> ${item.outcome}`,
+    '',
+    '## Done when',
+    hl(item.done_when),
+    '',
+    '## Verification',
+    code(item.verify),
+    '',
+    `## Review ${hl(day(item.review))}`,
+    '',
+    '## Log',
+  ];
+  if (!log.length) lines.push('- [ ] not verified yet');
+  else {
+    for (const entry of log) {
+      lines.push(`- [${entry.advanced ? 'x' : ' '}] ${entry.ts.slice(0, 16).replace('T', ' ')} `
+        + `${bold(entry.advanced ? 'PASS' : 'FAIL')} - ${entry.output || ''}`);
+    }
+  }
+  if (item.notes) lines.push('', '## Notes', item.notes);
+  lines.push('', `_item ${n}/${total} of this work stream_`);
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// dates — TickTick silently ignores a bare YYYY-MM-DD, so always send full ISO
+// ---------------------------------------------------------------------------
+
+function toIso(value, hour = 9) {
+  const v = String(value || '').trim();
+  if (!v) throw new Error('empty date');
+  let dt;
+  const rel = v.match(/^\+(\d+)$/);
+  if (rel) dt = new Date(Date.now() + Number(rel[1]) * 864e5);
+  else if (v.toLowerCase() === 'today') dt = new Date();
+  else if (v.toLowerCase() === 'tomorrow') dt = new Date(Date.now() + 864e5);
+  else if (/^\d{4}-\d{2}-\d{2}$/.test(v)) dt = new Date(`${v}T00:00:00`);
+  else {
+    dt = new Date(v);
+    if (Number.isNaN(dt.getTime())) throw new Error(`unparseable date: ${v}`);
+    return isoStamp(dt);
+  }
+  dt.setHours(hour, 0, 0, 0);
+  return isoStamp(dt);
+}
+
+function isoStamp(dt) {
+  const pad = (n, w = 2) => String(Math.abs(n)).padStart(w, '0');
+  const off = -dt.getTimezoneOffset();
+  const sign = off >= 0 ? '+' : '-';
+  return `${dt.getFullYear()}-${pad(dt.getMonth() + 1)}-${pad(dt.getDate())}`
+    + `T${pad(dt.getHours())}:${pad(dt.getMinutes())}:${pad(dt.getSeconds())}.000`
+    + `${sign}${pad(off / 60 | 0)}${pad(off % 60)}`;
+}
+
+function day(value) {
+  try { return toIso(value).slice(0, 10); } catch { return String(value); }
+}
+
+function isPast(value) {
+  const d = new Date(toIso(value));
+  const today = new Date(); today.setHours(0, 0, 0, 0);
+  return d < today;
+}
+
+// ---------------------------------------------------------------------------
+// the strict template + its gate
+// ---------------------------------------------------------------------------
+
+export const TEMPLATE = {
+  stream: {
+    title: '<outcome-shaped stream title>',
+    project: 'inbox',
+    outcome: '<one sentence, observable when it is true>',
+    review: '<YYYY-MM-DD - when the human reviews the whole stream>',
+    tags: [STREAM_TAG],
+  },
+  items: [1, 2].map(() => ({
+    title: '<outcome-shaped item title>',
+    outcome: '<the deliverable this item produces>',
+    done_when: '<the observable state that means done>',
+    verify: '<the exact command or reading that proves it>',
+    review: '<YYYY-MM-DD - required>',
+    notes: '',
+  })),
+};
+
+export function lint(spec) {
+  const errs = [];
+  if (!spec || typeof spec !== 'object' || !spec.stream || !spec.items) {
+    return ["spec needs a 'stream' object and an 'items' list - see: ats workstream template"];
+  }
+  const s = spec.stream;
+  for (const f of ['title', 'outcome', 'review']) {
+    const v = String(s[f] ?? '').trim();
+    if (!v) errs.push(`stream.${f} is required`);
+    else if (v.startsWith('<')) errs.push(`stream.${f} is still the template placeholder`);
+  }
+  if (String(s.title ?? '').length > TITLE_MAX) {
+    errs.push(`stream.title is ${s.title.length} chars, max ${TITLE_MAX} - it must read on one line`);
+  }
+  errs.push(...containerCheck('stream.title', s.title));
+  errs.push(...dateCheck('stream.review', s.review));
+
+  if (!Array.isArray(spec.items)) return errs.concat('items must be a list');
+  if (spec.items.length > MAX_ITEMS) {
+    errs.push(`HARD CAP: ${spec.items.length} work items, max ${MAX_ITEMS} per stream. `
+      + 'Split the rest into a second stream.');
+  }
+  if (spec.items.length < MIN_ITEMS) errs.push(`a stream needs at least ${MIN_ITEMS} work item`);
+
+  const seen = new Set();
+  spec.items.forEach((item, idx) => {
+    const i = idx + 1;
+    for (const f of ['title', 'outcome', 'done_when', 'verify', 'review']) {
+      const v = String(item[f] ?? '').trim();
+      if (!v) errs.push(`items[${i}].${f} is required`);
+      else if (v.startsWith('<')) errs.push(`items[${i}].${f} is still the template placeholder`);
+    }
+    const t = String(item.title ?? '');
+    if (t.length > TITLE_MAX) errs.push(`items[${i}].title is ${t.length} chars, max ${TITLE_MAX}`);
+    if (seen.has(t.toLowerCase())) errs.push(`items[${i}].title duplicates an earlier item`);
+    seen.add(t.toLowerCase());
+    errs.push(...containerCheck(`items[${i}].title`, t));
+    errs.push(...dateCheck(`items[${i}].review`, item.review));
+  });
+  return errs;
+}
+
+function containerCheck(field, title) {
+  const low = String(title ?? '').trim().toLowerCase();
+  for (const v of CONTAINER_VERBS) {
+    if (low.startsWith(`${v} `)) {
+      return [`${field} starts with the container verb '${v}' - name the outcome, not the activity`];
+    }
+  }
+  return [];
+}
+
+function dateCheck(field, value) {
+  const v = String(value ?? '').trim();
+  if (!v || v.startsWith('<')) return [];
+  try {
+    toIso(v);
+  } catch (err) {
+    return [`${field}: ${err.message}`];
+  }
+  return isPast(v) ? [`${field} is in the past (${day(v)}) - a review date must be reachable`] : [];
+}
+
+// ---------------------------------------------------------------------------
+// reading a stream back out of ATS — no local state, the tasks are the truth
+// ---------------------------------------------------------------------------
+
+async function readTask(adapter, t, projectId, taskId, live = true) {
+  if (t?.get) return t.get(projectId, taskId, ...(live ? [{ live: true }] : []));
+  return adapter.getTask(projectId, taskId);
+}
+
+async function loadStream(adapter, t, projectId, streamId) {
+  const parent = await readTask(adapter, t, projectId, streamId);
+  const childIds = parent.childIds || parent.task?.childIds || [];
+  if (!childIds.length) {
+    throw new Error(`task ${streamId} has no sub-tasks - is it a work stream? `
+      + 'Create one with: ats workstream create <spec.json>');
+  }
+  const items = await Promise.all(childIds.map((id) => readTask(adapter, t, projectId, id)));
+  // childIds order is not creation order, and `verify <n>` addresses an item by
+  // position - an unstable order would verify the wrong item. Creation order is
+  // spec order, because create writes the items in sequence.
+  items.sort((a, b) => String(a.createdTime || a.fullId || a.id)
+    .localeCompare(String(b.createdTime || b.fullId || b.id)));
+  return { parent, items };
+}
+
+function verifyLog(projectId, taskId) {
+  // The ledger filter keys are projectId/taskId. Re-assert the match locally so
+  // a filter that silently stops matching can never let one item's PASS count
+  // for another - a gate that passes when it should fail is the one bug this
+  // command exists to prevent.
+  return listActions({ projectId, taskId, action: VERIFY_ACTION })
+    .filter((a) => a.action === VERIFY_ACTION
+      && a.task?.projectId === projectId
+      && a.task?.taskId === taskId)
+    .sort((a, b) => String(a.ts).localeCompare(String(b.ts)));
+}
+
+function collect(projectId, parent, items) {
+  const rows = [];
+  let ok = true;
+  const capOk = items.length <= MAX_ITEMS;
+  ok = ok && capOk;
+  rows.push({ label: 'cap', detail: `${items.length} of max ${MAX_ITEMS} work items`, ok: capOk });
+
+  items.forEach((item, idx) => {
+    const id = item.fullId || item.id;
+    const log = verifyLog(projectId, id);
+    const last = log[log.length - 1];
+    const due = item.dueDate;
+    const passed = Boolean(last && last.advanced);
+    const rowOk = Boolean(due) && passed;
+    ok = ok && rowOk;
+    const detail = `review ${due ? String(due).slice(0, 10) : 'NO REVIEW DATE'} | `
+      + (passed ? `verified: ${String(last.output || '').slice(0, 60)}`
+        : last ? `FAILED: ${String(last.output || '').slice(0, 60)}`
+          : 'NOT VERIFIED');
+    rows.push({ label: `${idx + 1}/${items.length} ${String(item.title).slice(0, 38)}`, detail, ok: rowOk });
+  });
+
+  const streamDue = Boolean(parent.dueDate);
+  ok = ok && streamDue;
+  rows.push({ label: 'stream review', detail: parent.dueDate ? String(parent.dueDate).slice(0, 10) : 'NONE', ok: streamDue });
+  return { rows, ok };
+}
+
+function renderCheck(rows) {
+  const w = Math.max(...rows.map((r) => r.label.length));
+  return rows.map((r) => `  ${r.ok ? 'OK  ' : 'FAIL'}  ${r.label.padEnd(w)}  ${r.detail}`).join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// the command
+// ---------------------------------------------------------------------------
+
+export async function runWorkstream({
+  adapter, args, readSpec, urlFor, log = console.log, err = console.error,
+}) {
+  const sub = args.subcommand;
+  const t = adapter.__ext?.tasks;
+  const rest = args.positional;
+
+  switch (sub) {
+    case 'template':
+      log(JSON.stringify(TEMPLATE, null, 2));
+      return EXIT_OK;
+
+    case 'agent-brief':
+      log(BRIEF);
+      return EXIT_OK;
+
+    case 'lint': {
+      const spec = readSpec(rest[0]);
+      const errs = lint(spec);
+      if (errs.length) {
+        log(`LINT: ${errs.length} problem(s)`);
+        errs.forEach((e) => log(`  x ${e}`));
+        return EXIT_GATE;
+      }
+      log(`LINT: clean - ${spec.items.length} work item(s), all review dates set, `
+        + 'all verifications named');
+      return EXIT_OK;
+    }
+
+    case 'create': {
+      const spec = readSpec(rest[0]);
+      const errs = lint(spec);
+      if (errs.length) {
+        log('REFUSED - spec does not pass lint:');
+        errs.forEach((e) => log(`  x ${e}`));
+        return EXIT_GATE;
+      }
+      if (args.options['dry-run'] === true) {
+        log('DRY RUN - nothing written\n');
+        log(`STREAM: ${spec.stream.title}`);
+        log(renderStreamBody(spec, ''));
+        spec.items.forEach((item, i) => {
+          log(`\nITEM ${i + 1}: ${item.title}`);
+          log(renderItemBody(item, i + 1, spec.items.length, []));
+        });
+        return EXIT_OK;
+      }
+
+      const projectId = spec.stream.project || 'inbox';
+      const tags = spec.stream.tags?.length ? spec.stream.tags : [STREAM_TAG];
+
+      const parent = await createOne(adapter, t, projectId, {
+        title: spec.stream.title,
+        content: withMetadata(renderStreamBody(spec, ''), {
+          intent: { outcome: spec.stream.outcome, approvalRequired: true },
+          hierarchy: { kind: 'project' },
+        }),
+        dueDate: toIso(spec.stream.review),
+        tags,
+        priority: 'high',
+      });
+      const streamId = parent.fullId || parent.id;
+      const streamProject = parent.fullProjectId || parent.projectId || projectId;
+
+      const made = [];
+      for (const [idx, item] of spec.items.entries()) {
+        const child = await createOne(adapter, t, streamProject, {
+          title: item.title,
+          parentId: streamId,
+          content: withMetadata(renderItemBody(item, idx + 1, spec.items.length, []), {
+            intent: {
+              outcome: item.outcome,
+              doneWhen: [item.done_when],
+              authority: [item.verify],
+              approvalRequired: true,
+            },
+            hierarchy: { kind: 'task' },
+          }),
+          dueDate: toIso(item.review),
+          tags,
+        });
+        made.push(child);
+        recordAction({
+          action: 'workstream.item.created',
+          task: { projectId: streamProject, taskId: child.fullId || child.id },
+          sources: [streamId],
+          output: item.title,
+          advanced: true,
+        });
+      }
+
+      // The stream body can only name its own gate command once it has an id.
+      await updateOne(adapter, t, streamProject, streamId, {
+        content: withMetadata(renderStreamBody(spec, streamId), {
+          intent: { outcome: spec.stream.outcome, approvalRequired: true },
+          hierarchy: { kind: 'project' },
+        }),
+      });
+
+      log(`STREAM  ${spec.stream.title}`);
+      log(`        ${urlFor(streamProject, streamId)}`);
+      made.forEach((child, i) => {
+        log(`  ${i + 1}/${made.length}  ${spec.items[i].title}`);
+        log(`        review ${day(spec.items[i].review)}  `
+          + `${urlFor(streamProject, child.fullId || child.id)}`);
+      });
+      log(`\nstream id: ${streamId}`);
+      log(`next: do the work, then \`ats workstream verify ${streamId} <n> --evidence "..."\` per item,`);
+      log(`      then \`ats workstream ready ${streamId}\` before anything goes back to the human.`);
+      return EXIT_OK;
+    }
+
+    case 'verify': {
+      const [streamId, nRaw] = rest;
+      const n = Number(nRaw);
+      const evidence = args.options.evidence;
+      if (!streamId || !Number.isInteger(n)) {
+        err('Usage: ats workstream verify STREAM_ID ITEM_N --evidence "..." [--fail]');
+        return EXIT_ERR;
+      }
+      if (!evidence || typeof evidence !== 'string') {
+        err('--evidence is required: name the reading that proves it, not an opinion');
+        return EXIT_ERR;
+      }
+      const projectId = args.options.project || (await projectOf(adapter, t, streamId));
+      const { items } = await loadStream(adapter, t, projectId, streamId);
+      const item = items[n - 1];
+      if (!item) { err(`stream ${streamId} has no item ${n}`); return EXIT_ERR; }
+      const itemId = item.fullId || item.id;
+      const advanced = args.options.fail !== true;
+
+      recordAction({
+        action: VERIFY_ACTION,
+        task: { projectId, taskId: itemId },
+        sources: [streamId],
+        output: evidence,
+        advanced,
+      });
+
+      const spec = specFromTask(item, items.length, n);
+      await updateOne(adapter, t, projectId, itemId, {
+        content: withMetadata(
+          renderItemBody(spec, n, items.length, verifyLog(projectId, itemId)),
+          metadataOf(item),
+        ),
+      });
+      log(`item ${n}/${items.length}  ${advanced ? 'PASS' : 'FAIL'}  ${item.title}`);
+      log(`evidence: ${evidence}`);
+      log(urlFor(projectId, itemId));
+      return EXIT_OK;
+    }
+
+    case 'check':
+    case 'ready': {
+      const streamId = rest[0];
+      if (!streamId) { err(`Usage: ats workstream ${sub} STREAM_ID`); return EXIT_ERR; }
+      const projectId = args.options.project || (await projectOf(adapter, t, streamId));
+      const { parent, items } = await loadStream(adapter, t, projectId, streamId);
+      const { rows, ok } = collect(projectId, parent, items);
+      if (args.options.format === 'json') {
+        log(JSON.stringify({ ready: ok, checks: rows }, null, 2));
+        return ok ? EXIT_OK : EXIT_GATE;
+      }
+      log(renderCheck(rows));
+      if (sub === 'ready') {
+        log('');
+        log(ok
+          ? 'READY - every work item has a review date and a recorded PASS.\nThis stream may go back to the human.'
+          : 'NOT READY - do not hand this back yet.');
+      }
+      return ok ? EXIT_OK : EXIT_GATE;
+    }
+
+    case 'redate': {
+      const [streamId, which, when] = rest;
+      if (!streamId || !which || !when) {
+        err('Usage: ats workstream redate STREAM_ID <item-n|stream> YYYY-MM-DD');
+        return EXIT_ERR;
+      }
+      if (isPast(when)) { err(`${day(when)} is in the past - a review date must be reachable`); return EXIT_ERR; }
+      const projectId = args.options.project || (await projectOf(adapter, t, streamId));
+      const iso = toIso(when);
+      if (which === 'stream') {
+        await updateOne(adapter, t, projectId, streamId, { dueDate: iso });
+        log(`stream review -> ${day(when)}  ${urlFor(projectId, streamId)}`);
+        return EXIT_OK;
+      }
+      const n = Number(which);
+      const { items } = await loadStream(adapter, t, projectId, streamId);
+      const item = items[n - 1];
+      if (!item) { err(`stream ${streamId} has no item ${n}`); return EXIT_ERR; }
+      const itemId = item.fullId || item.id;
+      const spec = specFromTask(item, items.length, n);
+      spec.review = when;
+      await updateOne(adapter, t, projectId, itemId, {
+        dueDate: iso,
+        content: withMetadata(
+          renderItemBody(spec, n, items.length, verifyLog(projectId, itemId)),
+          metadataOf(item),
+        ),
+      });
+      log(`item ${n} review -> ${day(when)}  ${urlFor(projectId, itemId)}`);
+      return EXIT_OK;
+    }
+
+    case 'show': {
+      const streamId = rest[0];
+      if (!streamId) { err('Usage: ats workstream show STREAM_ID'); return EXIT_ERR; }
+      const projectId = args.options.project || (await projectOf(adapter, t, streamId));
+      const { parent, items } = await loadStream(adapter, t, projectId, streamId);
+      log(`STREAM  ${parent.title}`);
+      log(`        ${urlFor(projectId, streamId)}`);
+      items.forEach((item, i) => {
+        const id = item.fullId || item.id;
+        const last = verifyLog(projectId, id).slice(-1)[0];
+        const state = item.status === 'completed' || item.status === 2 ? 'done' : 'open';
+        log(`  ${i + 1}  [${state}/${last ? (last.advanced ? 'pass' : 'fail') : 'unverified'}] ${item.title}`);
+        log(`     review ${item.dueDate ? String(item.dueDate).slice(0, 10) : 'none'}  ${urlFor(projectId, id)}`);
+      });
+      return EXIT_OK;
+    }
+
+    case 'list': {
+      const entries = listActions({ action: 'workstream.item.created' });
+      const streams = new Map();
+      for (const a of entries) for (const s of a.sources || []) {
+        streams.set(s, (streams.get(s) || 0) + 1);
+      }
+      if (!streams.size) { log('no work streams scaffolded yet'); return EXIT_OK; }
+      for (const [id, n] of streams) log(`${id}  ${n} item(s)`);
+      return EXIT_OK;
+    }
+
+    default:
+      err(`Unknown workstream subcommand: ${sub || '(none)'}`);
+      err("Run 'ats workstream --help'.");
+      return EXIT_ERR;
+  }
+}
+
+// --- helpers ---------------------------------------------------------------
+
+function withMetadata(body, patch) {
+  return writeTaskMetadata(body, patch);
+}
+
+function metadataOf(task) {
+  const meta = parseTaskMetadata(task.content || '');
+  return meta || {};
+}
+
+/** Rebuild the render inputs from what ATS already stores on the task. */
+function specFromTask(task, total, n) {
+  const meta = parseTaskMetadata(task.content || '') || {};
+  const intent = meta.intent || {};
+  return {
+    title: task.title,
+    outcome: intent.outcome || '',
+    done_when: (intent.doneWhen || [])[0] || '',
+    verify: (intent.authority || [])[0] || '',
+    review: task.dueDate || '',
+    notes: '',
+    _n: n,
+    _total: total,
+  };
+}
+
+async function createOne(adapter, t, projectId, input) {
+  if (t?.create) {
+    const r = await t.create(projectId, input.title, input);
+    return r.task || r;
+  }
+  return adapter.createTask({ ...input, projectId });
+}
+
+async function updateOne(adapter, t, projectId, taskId, patch) {
+  if (t?.update) return t.update(projectId, taskId, patch, { live: true });
+  return adapter.updateTask(projectId, taskId, patch);
+}
+
+/** Resolve which project a stream lives in without touching any cache file. */
+async function projectOf(adapter, t, taskId) {
+  for (const ref of ['inbox']) {
+    try {
+      const task = await readTask(adapter, t, ref, taskId);
+      if (task) return task.fullProjectId || task.projectId || ref;
+    } catch { /* fall through to the project scan */ }
+  }
+  const projects = await adapter.listProjects();
+  for (const p of projects) {
+    try {
+      const task = await readTask(adapter, t, p.id, taskId);
+      if (task) return task.fullProjectId || task.projectId || p.id;
+    } catch { /* not in this lane */ }
+  }
+  throw new Error(`could not locate task ${taskId} - pass --project <id>`);
+}
+
+export const BRIEF = `ats workstream - the contract for any agent
+
+WHY: the human's capacity to process information is limited. A work stream that
+lands in the task app must be small, scannable, dated, and already verified.
+
+THE FIVE RULES - all enforced, none optional:
+  1. MAX ${MAX_ITEMS} work items per stream. A fourth is refused. Split instead.
+  2. Every work item has a REVIEW DATE, re-read live from the store on every
+     check, so a date cleared in the app turns the gate red.
+  3. Every work item names its VERIFICATION - the exact command or reading
+     that proves it - decided BEFORE the work starts.
+  4. Titles name an OUTCOME, not an activity. Container verbs are rejected.
+  5. Bodies are RENDERED from the spec, never hand-authored.
+
+THE LOOP:
+  ats workstream template > stream.json
+  ats workstream lint stream.json          # exit 2 until the spec is clean
+  ats workstream create stream.json        # parent + 2-3 real sub-tasks
+  ... do the work ...
+  ats workstream verify <stream> <n> --evidence "<what you observed>"
+  ats workstream ready <stream>            # exit 0 ONLY when every item passed
+  # exit 0 is the permission to go back to the human. Nothing else is.
+
+WHERE THE STATE LIVES: nowhere private. Membership is real sub-tasks, the
+outcome and done-when are intent metadata, the verification log is the ATS
+action ledger, the review date is the task due date. 'ats intent get',
+'ats hierarchy get', 'ats ledger list' and 'ats undo' all work on these tasks.
+
+EVIDENCE means a reading, not an opinion. "tests pass" is not evidence;
+"pytest -q -> 34 passed in 2.1s" is. A --fail verification is a legitimate
+outcome; it keeps 'ready' red until the work is actually done.`;

--- a/packages/cli/workstream.js
+++ b/packages/cli/workstream.js
@@ -43,8 +43,39 @@ export const EXIT_GATE = 2;
 // readability — ::colon highlight:: is the primary marker, one per section
 // ---------------------------------------------------------------------------
 
-const HL = process.env.ATS_WORKSTREAM_HIGHLIGHT || '::{}::';
-const hl = (text) => HL.replace('{}', String(text).trim().replace(/:+$/, ''));
+/**
+ * Colour is DERIVED from gate state, never chosen by an agent or a human.
+ * That is the whole reason the rule survives: every colour below is a state
+ * this command already computes, so nothing has to be remembered or picked,
+ * and a body re-renders to the same colours every time.
+ *
+ *   outcome  what must become true      the thing being aimed at
+ *   date     the review date            when it lands in front of the human
+ *   pass     verified with evidence     safe to hand back
+ *   fail     failed or blocked          needs a decision
+ *
+ * Blue and purple are deliberately left unassigned. An unused colour keeps its
+ * signal; spending all six on nothing in particular is how a scheme goes numb.
+ *
+ * MARKUP is the single place to change once TickTick's per-colour syntax is
+ * confirmed from the app. Until then every role renders as the plain
+ * double-colon highlight, which is what shipped and what already reads well.
+ */
+const MARKUP = {
+  plain: '::{}::',
+  outcome: process.env.ATS_HL_OUTCOME || '::{}::',   // cyan
+  date: process.env.ATS_HL_DATE || '::{}::',         // yellow
+  pass: process.env.ATS_HL_PASS || '::{}::',         // green
+  fail: process.env.ATS_HL_FAIL || '::{}::',         // red
+};
+
+const clean = (text) => String(text).trim().replace(/:+$/, '');
+
+/** hl(text) keeps the plain marker; hl(text, 'pass') asks for a gate colour. */
+const hl = (text, role = 'plain') => {
+  const tmpl = process.env.ATS_WORKSTREAM_HIGHLIGHT || MARKUP[role] || MARKUP.plain;
+  return tmpl.replace('{}', clean(text));
+};
 const bold = (text) => `**${text}**`;
 const code = (text) => '`' + String(text).replace(/`/g, "'") + '`';
 
@@ -52,12 +83,12 @@ function renderStreamBody(spec, streamId) {
   const { stream, items } = spec;
   const lines = [
     '## Outcome',
-    `> ${hl(stream.outcome)}`,
+    `> ${hl(stream.outcome, 'outcome')}`,
     '',
     `## Work items ${hl(`${items.length} of max ${MAX_ITEMS}`)}`,
   ];
   items.forEach((item, i) => {
-    lines.push(`${i + 1}. ${bold(item.title)} ${hl(`review ${day(item.review)}`)}`);
+    lines.push(`${i + 1}. ${bold(item.title)} ${hl(`review ${day(item.review)}`, 'date')}`);
   });
   lines.push(
     '',
@@ -72,7 +103,7 @@ function renderItemBody(item, n, total, log) {
   const last = log[log.length - 1];
   const status = !last
     ? hl('NOT VERIFIED YET')
-    : last.advanced ? hl('VERIFIED') : hl('VERIFICATION FAILED');
+    : last.advanced ? hl('VERIFIED', 'pass') : hl('VERIFICATION FAILED', 'fail');
   const lines = [
     status,
     '',
@@ -80,12 +111,12 @@ function renderItemBody(item, n, total, log) {
     `> ${item.outcome}`,
     '',
     '## Done when',
-    hl(item.done_when),
+    hl(item.done_when, 'outcome'),
     '',
     '## Verification',
     code(item.verify),
     '',
-    `## Review ${hl(day(item.review))}`,
+    `## Review ${hl(day(item.review), 'date')}`,
     '',
     '## Log',
   ];
@@ -503,6 +534,40 @@ export async function runWorkstream({
         ),
       });
       log(`item ${n} review -> ${day(when)}  ${urlFor(projectId, itemId)}`);
+      return EXIT_OK;
+    }
+
+    case 'rerender': {
+      // Bodies are rendered, never hand-authored, so a template change (a new
+      // highlight colour, a new section) is applied here rather than by editing
+      // tasks in the app. Everything it needs is already on the tasks.
+      const streamId = rest[0];
+      if (!streamId) { err('Usage: ats workstream rerender STREAM_ID'); return EXIT_ERR; }
+      const projectId = args.options.project || (await projectOf(adapter, t, streamId));
+      const { parent, items } = await loadStream(adapter, t, projectId, streamId);
+      const parentMeta = metadataOf(parent);
+      const specItems = items.map((item, i) => specFromTask(item, items.length, i + 1));
+
+      await updateOne(adapter, t, projectId, streamId, {
+        content: withMetadata(renderStreamBody({
+          stream: {
+            outcome: parentMeta.intent?.outcome || '',
+            review: parent.dueDate || '',
+          },
+          items: specItems,
+        }, streamId), parentMeta),
+      });
+      for (const [idx, item] of items.entries()) {
+        const itemId = item.fullId || item.id;
+        await updateOne(adapter, t, projectId, itemId, {
+          content: withMetadata(
+            renderItemBody(specItems[idx], idx + 1, items.length, verifyLog(projectId, itemId)),
+            metadataOf(item),
+          ),
+        });
+      }
+      log(`re-rendered ${items.length + 1} task(s)`);
+      log(urlFor(projectId, streamId));
       return EXIT_OK;
     }
 

--- a/packages/cli/workstream.js
+++ b/packages/cli/workstream.js
@@ -62,11 +62,13 @@ export const EXIT_GATE = 2;
  * double-colon highlight, which is what shipped and what already reads well.
  */
 const MARKUP = {
+  // `::x::` is the uncoloured highlight already in wide use. A colour is the
+  // `=={#hex}x==` form, confirmed against the TickTick editor 2026-09-07.
   plain: '::{}::',
-  outcome: process.env.ATS_HL_OUTCOME || '::{}::',   // cyan
-  date: process.env.ATS_HL_DATE || '::{}::',         // yellow
-  pass: process.env.ATS_HL_PASS || '::{}::',         // green
-  fail: process.env.ATS_HL_FAIL || '::{}::',         // red
+  outcome: process.env.ATS_HL_OUTCOME || '=={#57DEE2}{}==',  // cyan
+  date: process.env.ATS_HL_DATE || '=={#FFE500}{}==',        // yellow
+  pass: process.env.ATS_HL_PASS || '=={#6FF143}{}==',        // green
+  fail: process.env.ATS_HL_FAIL || '=={#FD848D}{}==',        // red
 };
 
 const clean = (text) => String(text).trim().replace(/:+$/, '');
@@ -74,6 +76,8 @@ const clean = (text) => String(text).trim().replace(/:+$/, '');
 /** hl(text) keeps the plain marker; hl(text, 'pass') asks for a gate colour. */
 const hl = (text, role = 'plain') => {
   const tmpl = process.env.ATS_WORKSTREAM_HIGHLIGHT || MARKUP[role] || MARKUP.plain;
+  // Only the empty `{}` placeholder is substituted, never the `{#hex}` colour
+  // token that sits beside it.
   return tmpl.replace('{}', clean(text));
 };
 const bold = (text) => `**${text}**`;


### PR DESCRIPTION
Adds `ats workstream`: one parent task plus 2-3 sub-tasks, each carrying a review
date and a named verification, behind a gate that only opens once every item has
a recorded PASS with evidence. The premise is that a human's capacity to process
information is limited, so what reaches them should be small, scannable, dated,
and already verified — structurally, not by agent discipline.

**It stores nothing of its own.** Membership is real sub-tasks, outcome and
done-when are `intent` metadata, the verification log is the action ledger, the
review date is the task due date. `ats intent get`, `ats hierarchy get`,
`ats ledger list` and `ats undo` all read a work stream as an ordinary task
graph, so this is an ATS operation rather than a second interface.

```
ats workstream template > stream.json
ats workstream lint stream.json        # exit 2 until the spec is clean
ats workstream create stream.json
ats workstream verify <id> <n> --evidence "<observed reading>"
ats workstream ready <id>              # exit 0 = permission to report back
```

### Adapter capabilities this needed

All additive, defaults unchanged:

- `tasks create --parent <id>` — a real nested sub-task. `hierarchy set` only
  ever wrote a `## Related` link into the description while `parentId` stayed
  null.
- `tasks get|update --live` — bypass the local cache. Cached reads are right for
  retrieval and wrong for a gate, since a review date cleared in the app would go
  unseen; on update it also drops the cached merge base so a concurrent edit is
  not clobbered. The extra adapter argument is passed only when `--live` is set,
  so the documented call signature is unchanged.
- `tasks create|update --raw` — the per-call form of `format-skip`, so a body
  rendered deterministically by a tool survives byte-for-byte.
- The TickTick task mapping now surfaces `parentId` and `childIds`, which it had
  been dropping, making a parent's children invisible to every caller.

### Vector-sync fix

`syncVectors` called the `embedding` module directly instead of the injected
`embedder`, so `options.embedding` was silently ignored and the path could not be
tested. The stale test that pinned the removed delegation is replaced by one that
pins the behaviour the cache-based rewrite introduced: index from the local cache
so Inbox tasks reach the index, and exclude completed tasks.

### Readability

Highlight colour is derived from gate state, never chosen: cyan outcome, yellow
review date, green verified, red failed. Blue and purple stay unassigned so they
keep their signal. The markup is TickTick's `=={#hex}text==` form.

307 tests pass; lint, claims and every prove script are green.
